### PR TITLE
Fix/memory leak

### DIFF
--- a/kaleidux-common/src/lib.rs
+++ b/kaleidux-common/src/lib.rs
@@ -1,4 +1,11 @@
-#![allow(dead_code, unused_variables, unused_mut, unused_imports, unused_assignments, unused_attributes)]
+#![allow(
+    dead_code,
+    unused_variables,
+    unused_mut,
+    unused_imports,
+    unused_assignments,
+    unused_attributes
+)]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -15,22 +22,13 @@ pub enum Request {
     #[serde(rename = "query_outputs")]
     QueryOutputs,
     #[serde(rename = "next")]
-    Next {
-        output: Option<String>,
-    },
+    Next { output: Option<String> },
     #[serde(rename = "prev")]
-    Prev {
-        output: Option<String>,
-    },
+    Prev { output: Option<String> },
     #[serde(rename = "love")]
-    Love {
-        path: String,
-        multiplier: f32,
-    },
+    Love { path: String, multiplier: f32 },
     #[serde(rename = "unlove")]
-    Unlove {
-        path: String,
-    },
+    Unlove { path: String },
     #[serde(rename = "loveitlist")]
     LoveitList,
     #[serde(rename = "pause")]
@@ -42,9 +40,7 @@ pub enum Request {
     #[serde(rename = "reload")]
     Reload,
     #[serde(rename = "clear")]
-    Clear {
-        output: Option<String>,
-    },
+    Clear { output: Option<String> },
     #[serde(rename = "kill")]
     Kill,
     #[serde(rename = "playlist")]
@@ -83,249 +79,412 @@ pub enum BlacklistCommand {
     List,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[serde(rename_all = "kebab-case", tag = "type")]
 pub enum Transition {
-    Angular { #[serde(default = "df_0")] starting_angle: f32 },
+    Angular {
+        #[serde(default = "df_0")]
+        starting_angle: f32,
+    },
     BookFlip,
-    Bounce { 
-        #[serde(default = "df_black_alpha")] shadow_colour: [f32; 4], 
-        #[serde(default = "df_0_075")] shadow_height: f32, 
-        #[serde(default = "df_3")] bounces: f32 
+    Bounce {
+        #[serde(default = "df_black_alpha")]
+        shadow_colour: [f32; 4],
+        #[serde(default = "df_0_075")]
+        shadow_height: f32,
+        #[serde(default = "df_3")]
+        bounces: f32,
     },
     BowTieHorizontal,
     BowTieVertical,
-    BowTieWithParameter { 
-        #[serde(default = "df_0_5")] adjust: f32, 
-        #[serde(default = "df_false")] reverse: bool 
+    BowTieWithParameter {
+        #[serde(default = "df_0_5")]
+        adjust: f32,
+        #[serde(default = "df_false")]
+        reverse: bool,
     },
     Burn,
-    ButterflyWaveScrawler { 
-        #[serde(default = "df_1")] amplitude: f32, 
-        #[serde(default = "df_30")] waves: f32, 
-        #[serde(default = "df_0_3")] color_separation: f32 
+    ButterflyWaveScrawler {
+        #[serde(default = "df_1")]
+        amplitude: f32,
+        #[serde(default = "df_30")]
+        waves: f32,
+        #[serde(default = "df_0_3")]
+        color_separation: f32,
     },
     CannabisLeaf,
     Circle,
-    CircleCrop { #[serde(default = "df_black_rgba")] bgcolor: [f32; 4] },
-    CircleOpen { 
-        #[serde(default = "df_0_3")] smoothness: f32, 
-        #[serde(default = "df_true")] opening: bool 
+    CircleCrop {
+        #[serde(default = "df_black_rgba")]
+        bgcolor: [f32; 4],
+    },
+    CircleOpen {
+        #[serde(default = "df_0_3")]
+        smoothness: f32,
+        #[serde(default = "df_true")]
+        opening: bool,
     },
     ColorPhase,
     CoordFromIn,
-    CrazyParametricFun { 
-        #[serde(default = "df_4")] a: f32, 
-        #[serde(default = "df_1")] b: f32, 
-        #[serde(default = "df_120")] amplitude: f32, 
-        #[serde(default = "df_0_1")] smoothness: f32 
+    CrazyParametricFun {
+        #[serde(default = "df_4")]
+        a: f32,
+        #[serde(default = "df_1")]
+        b: f32,
+        #[serde(default = "df_120")]
+        amplitude: f32,
+        #[serde(default = "df_0_1")]
+        smoothness: f32,
     },
-    ColourDistance { #[serde(default = "df_5")] power: f32 },
+    ColourDistance {
+        #[serde(default = "df_5")]
+        power: f32,
+    },
     CrossHatch,
     CrossWarp,
-    CrossZoom { #[serde(default = "df_0_4")] strength: f32 },
-    Cube { 
-        #[serde(default = "df_0_7")] persp: f32, 
-        #[serde(default = "df_0_3")] unzoom: f32, 
-        #[serde(default = "df_0_4")] reflection: f32, 
-        #[serde(default = "df_3")] floating: f32 
+    CrossZoom {
+        #[serde(default = "df_0_4")]
+        strength: f32,
     },
-    Directional { #[serde(default = "df_y_up")] direction: [f32; 2] },
-    DirectionalEasing { #[serde(default = "df_y_up")] direction: [f32; 2] },
-    DirectionalScaled { 
-        #[serde(default = "df_y_up")] direction: [f32; 2], 
-        #[serde(default = "df_0_7")] scale: f32 
+    Cube {
+        #[serde(default = "df_0_7")]
+        persp: f32,
+        #[serde(default = "df_0_3")]
+        unzoom: f32,
+        #[serde(default = "df_0_4")]
+        reflection: f32,
+        #[serde(default = "df_3")]
+        floating: f32,
     },
-    DirectionalWarp { #[serde(default = "df_y_up")] direction: [f32; 2] },
+    Directional {
+        #[serde(default = "df_y_up")]
+        direction: [f32; 2],
+    },
+    DirectionalEasing {
+        #[serde(default = "df_y_up")]
+        direction: [f32; 2],
+    },
+    DirectionalScaled {
+        #[serde(default = "df_y_up")]
+        direction: [f32; 2],
+        #[serde(default = "df_0_7")]
+        scale: f32,
+    },
+    DirectionalWarp {
+        #[serde(default = "df_y_up")]
+        direction: [f32; 2],
+    },
     #[serde(alias = "wipe")]
-    DirectionalWipe { 
+    DirectionalWipe {
         #[serde(default = "default_wipe_direction")]
-        direction: [f32; 2], 
+        direction: [f32; 2],
         #[serde(default = "default_wipe_smoothness")]
-        smoothness: f32 
+        smoothness: f32,
     },
     Displacement,
-    Dissolve { 
-        #[serde(default = "df_0_1")] line_width: f32, 
-        #[serde(default = "df_red")] spread_clr: [f32; 3], 
-        #[serde(default = "df_yellow")] hot_clr: [f32; 3], 
-        #[serde(default = "df_5")] pow: f32, 
-        #[serde(default = "df_1")] intensity: f32 
+    Dissolve {
+        #[serde(default = "df_0_1")]
+        line_width: f32,
+        #[serde(default = "df_red")]
+        spread_clr: [f32; 3],
+        #[serde(default = "df_yellow")]
+        hot_clr: [f32; 3],
+        #[serde(default = "df_5")]
+        pow: f32,
+        #[serde(default = "df_1")]
+        intensity: f32,
     },
-    Doom { 
-        #[serde(default = "df_30_i")] bars: i32, 
-        #[serde(default = "df_2")] amplitude: f32, 
-        #[serde(default = "df_0_1")] noise: f32, 
-        #[serde(default = "df_0_5")] frequency: f32, 
-        #[serde(default = "df_0_5")] drip_scale: f32 
+    Doom {
+        #[serde(default = "df_30_i")]
+        bars: i32,
+        #[serde(default = "df_2")]
+        amplitude: f32,
+        #[serde(default = "df_0_1")]
+        noise: f32,
+        #[serde(default = "df_0_5")]
+        frequency: f32,
+        #[serde(default = "df_0_5")]
+        drip_scale: f32,
     },
-    Doorway { 
-        #[serde(default = "df_0_4")] reflection: f32, 
-        #[serde(default = "df_0_4")] perspective: f32, 
-        #[serde(default = "df_3")] depth: f32 
+    Doorway {
+        #[serde(default = "df_0_4")]
+        reflection: f32,
+        #[serde(default = "df_0_4")]
+        perspective: f32,
+        #[serde(default = "df_3")]
+        depth: f32,
     },
     Dreamy,
-    DreamyZoom { 
-        #[serde(default = "df_6")] rotation: f32, 
-        #[serde(default = "df_1_2")] scale: f32 
+    DreamyZoom {
+        #[serde(default = "df_6")]
+        rotation: f32,
+        #[serde(default = "df_1_2")]
+        scale: f32,
     },
-    Edge { 
-        #[serde(default = "df_tiny")] thickness: f32, 
-        #[serde(default = "df_8")] brightness: f32 
+    Edge {
+        #[serde(default = "df_tiny")]
+        thickness: f32,
+        #[serde(default = "df_8")]
+        brightness: f32,
     },
+    #[default]
     Fade,
-    FadeColor { 
-        #[serde(default = "df_black_rgb")] color: [f32; 3], 
-        #[serde(default = "df_0_4")] color_phase: f32 
+    FadeColor {
+        #[serde(default = "df_black_rgb")]
+        color: [f32; 3],
+        #[serde(default = "df_0_4")]
+        color_phase: f32,
     },
-    FadeGrayscale { #[serde(default = "df_0_3")] intensity: f32 },
-    FilmBurn { #[serde(default = "df_2_31")] seed: f32 },
-    FlyEye { 
-        #[serde(default = "df_0_04")] size: f32, 
-        #[serde(default = "df_0_5")] zoom: f32, 
-        #[serde(default = "df_0_3")] color_separation: f32 
+    FadeGrayscale {
+        #[serde(default = "df_0_3")]
+        intensity: f32,
+    },
+    FilmBurn {
+        #[serde(default = "df_2_31")]
+        seed: f32,
+    },
+    FlyEye {
+        #[serde(default = "df_0_04")]
+        size: f32,
+        #[serde(default = "df_0_5")]
+        zoom: f32,
+        #[serde(default = "df_0_3")]
+        color_separation: f32,
     },
     GlitchDisplace,
     GlitchMemories,
-    GridFlip { 
-        #[serde(default = "df_4_4")] size: [i32; 2], 
-        #[serde(default = "df_0_1")] pause: f32, 
-        #[serde(default = "df_0_05")] divider_width: f32, 
-        #[serde(default = "df_black_rgba")] bgcolor: [f32; 4], 
-        #[serde(default = "df_0_1")] randomness: f32 
+    GridFlip {
+        #[serde(default = "df_4_4")]
+        size: [i32; 2],
+        #[serde(default = "df_0_1")]
+        pause: f32,
+        #[serde(default = "df_0_05")]
+        divider_width: f32,
+        #[serde(default = "df_black_rgba")]
+        bgcolor: [f32; 4],
+        #[serde(default = "df_0_1")]
+        randomness: f32,
     },
     Heart,
-    Hexagonalize { 
-        #[serde(default = "df_50_i")] steps: i32, 
-        #[serde(default = "df_20")] horizontal_hexagons: f32 
+    Hexagonalize {
+        #[serde(default = "df_50_i")]
+        steps: i32,
+        #[serde(default = "df_20")]
+        horizontal_hexagons: f32,
     },
     HorizontalClose,
     HorizontalOpen,
     InvertedPageCurl,
-    Kaleidoscope { 
-        #[serde(default = "df_0_5")] speed: f32, 
-        #[serde(default = "df_1")] angle: f32, 
-        #[serde(default = "df_0_3")] power: f32 
+    Kaleidoscope {
+        #[serde(default = "df_0_5")]
+        speed: f32,
+        #[serde(default = "df_1")]
+        angle: f32,
+        #[serde(default = "df_0_3")]
+        power: f32,
     },
     LeftRight,
-    LinearBlur { #[serde(default = "df_0_1")] intensity: f32 },
+    LinearBlur {
+        #[serde(default = "df_0_1")]
+        intensity: f32,
+    },
     Luma,
-    LuminanceMelt { 
-        #[serde(default = "df_true")] direction: bool, 
-        #[serde(rename = "luma_threshold", default = "df_0_05")] luma_threshold: f32 
+    LuminanceMelt {
+        #[serde(default = "df_true")]
+        direction: bool,
+        #[serde(rename = "luma_threshold", default = "df_0_05")]
+        luma_threshold: f32,
     },
-    Morph { #[serde(default = "df_0_1")] strength: f32 },
-    Mosaic { 
-        #[serde(default = "df_2_i")] endx: i32, 
-        #[serde(default = "df_neg_1_i")] endy: i32 
+    Morph {
+        #[serde(default = "df_0_1")]
+        strength: f32,
     },
-    MosaicTransition { #[serde(default = "df_10")] mosaic_num: f32 },
+    Mosaic {
+        #[serde(default = "df_2_i")]
+        endx: i32,
+        #[serde(default = "df_neg_1_i")]
+        endy: i32,
+    },
+    MosaicTransition {
+        #[serde(default = "df_10")]
+        mosaic_num: f32,
+    },
     MultiplyBlend,
     Overexposure,
-    Perlin { 
-        #[serde(default = "df_4")] scale: f32, 
-        #[serde(default = "df_0_01")] smoothness: f32, 
-        #[serde(default = "df_12")] seed: f32 
+    Perlin {
+        #[serde(default = "df_4")]
+        scale: f32,
+        #[serde(default = "df_0_01")]
+        smoothness: f32,
+        #[serde(default = "df_12")]
+        seed: f32,
     },
-    Pinwheel { #[serde(default = "df_2")] speed: f32 },
-    Pixelize { 
-        #[serde(default = "df_20_20")] squares_min: [i32; 2], 
-        #[serde(default = "df_50_i")] steps: i32 
+    Pinwheel {
+        #[serde(default = "df_2")]
+        speed: f32,
     },
-    PolarFunction { #[serde(default = "df_5_i")] segments: i32 },
-    PolkaDotsCurtain { 
-        #[serde(default = "df_20")] dots: f32, 
-        #[serde(default = "df_origin")] center: [f32; 2] 
+    Pixelize {
+        #[serde(default = "df_20_20")]
+        squares_min: [i32; 2],
+        #[serde(default = "df_50_i")]
+        steps: i32,
     },
-    PowerKaleido { 
-        #[serde(default = "df_2")] scale: f32, 
-        #[serde(default = "df_1_5")] radius: f32, 
-        #[serde(default = "df_0")] angle: f32 
+    PolarFunction {
+        #[serde(default = "df_5_i")]
+        segments: i32,
     },
-    Radial { 
+    PolkaDotsCurtain {
+        #[serde(default = "df_20")]
+        dots: f32,
+        #[serde(default = "df_origin")]
+        center: [f32; 2],
+    },
+    PowerKaleido {
+        #[serde(default = "df_2")]
+        scale: f32,
+        #[serde(default = "df_1_5")]
+        radius: f32,
+        #[serde(default = "df_0")]
+        angle: f32,
+    },
+    Radial {
         #[serde(default = "default_radial_smoothness")]
-        smoothness: f32 
+        smoothness: f32,
     },
     RandomNoiseX,
-    RandomSquares { 
-        #[serde(default = "df_10_10")] size: [i32; 2], 
-        #[serde(default = "df_0_5")] smoothness: f32 
+    RandomSquares {
+        #[serde(default = "df_10_10")]
+        size: [i32; 2],
+        #[serde(default = "df_0_5")]
+        smoothness: f32,
     },
-    Rectangle { #[serde(default = "df_black_rgba")] bgcolor: [f32; 4] },
-    RectangleCrop { #[serde(default = "df_black_rgba")] bgcolor: [f32; 4] },
-    Ripple { 
-        #[serde(default = "df_100")] amplitude: f32, 
-        #[serde(default = "df_50_f")] speed: f32 
+    Rectangle {
+        #[serde(default = "df_black_rgba")]
+        bgcolor: [f32; 4],
     },
-    Rolls { 
-        #[serde(rename = "rolls_type", default = "df_0_i")] rolls_type: i32, 
-        #[serde(rename = "rot_down", default = "df_false")] rot_down: bool 
+    RectangleCrop {
+        #[serde(default = "df_black_rgba")]
+        bgcolor: [f32; 4],
+    },
+    Ripple {
+        #[serde(default = "df_100")]
+        amplitude: f32,
+        #[serde(default = "df_50_f")]
+        speed: f32,
+    },
+    Rolls {
+        #[serde(rename = "rolls_type", default = "df_0_i")]
+        rolls_type: i32,
+        #[serde(rename = "rot_down", default = "df_false")]
+        rot_down: bool,
     },
     Rotate,
-    RotateScaleFade { 
-        #[serde(default = "df_center")] center: [f32; 2], 
-        #[serde(default = "df_1")] rotations: f32, 
-        #[serde(default = "df_8_f")] scale: f32, 
-        #[serde(rename = "back_color", default = "df_dark_grey")] back_color: [f32; 4] 
+    RotateScaleFade {
+        #[serde(default = "df_center")]
+        center: [f32; 2],
+        #[serde(default = "df_1")]
+        rotations: f32,
+        #[serde(default = "df_8_f")]
+        scale: f32,
+        #[serde(rename = "back_color", default = "df_dark_grey")]
+        back_color: [f32; 4],
     },
-    RotateScaleVanish { 
-        #[serde(rename = "fade_in_second", default = "df_true")] fade_in_second: bool, 
-        #[serde(rename = "reverse_effect", default = "df_false")] reverse_effect: bool, 
-        #[serde(rename = "reverse_rotation", default = "df_false")] reverse_rotation: bool 
+    RotateScaleVanish {
+        #[serde(rename = "fade_in_second", default = "df_true")]
+        fade_in_second: bool,
+        #[serde(rename = "reverse_effect", default = "df_false")]
+        reverse_effect: bool,
+        #[serde(rename = "reverse_rotation", default = "df_false")]
+        reverse_rotation: bool,
     },
     ScaleIn,
-    SimpleZoom { #[serde(default = "df_0_8")] zoom_quickness: f32 },
-    SimpleZoomOut { 
-        #[serde(default = "df_0_8")] zoom_quickness: f32, 
-        #[serde(default = "df_true")] fade_edge: bool 
+    SimpleZoom {
+        #[serde(default = "df_0_8")]
+        zoom_quickness: f32,
     },
-    Slides { 
-        #[serde(rename = "slides_type", default = "df_0_i")] slides_type: i32, 
-        #[serde(rename = "slides_in", default = "df_false")] slides_in: bool 
+    SimpleZoomOut {
+        #[serde(default = "df_0_8")]
+        zoom_quickness: f32,
+        #[serde(default = "df_true")]
+        fade_edge: bool,
     },
-    SquaresWire { 
-        #[serde(default = "df_10_10")] squares: [i32; 2], 
-        #[serde(default = "df_x_up")] direction: [f32; 2], 
-        #[serde(default = "df_1_6")] smoothness: f32 
+    Slides {
+        #[serde(rename = "slides_type", default = "df_0_i")]
+        slides_type: i32,
+        #[serde(rename = "slides_in", default = "df_false")]
+        slides_in: bool,
     },
-    Squeeze { #[serde(default = "df_0_1")] color_separation: f32 },
-    StaticFade { 
-        #[serde(default = "df_200")] n_noise_pixels: f32, 
-        #[serde(default = "df_0_8")] static_luminosity: f32 
+    SquaresWire {
+        #[serde(default = "df_10_10")]
+        squares: [i32; 2],
+        #[serde(default = "df_x_up")]
+        direction: [f32; 2],
+        #[serde(default = "df_1_6")]
+        smoothness: f32,
     },
-    StaticWipe { 
-        #[serde(default = "df_true")] up_to_down: bool, 
-        #[serde(default = "df_0_5")] max_static_span: f32 
+    Squeeze {
+        #[serde(default = "df_0_1")]
+        color_separation: f32,
     },
-    StereoViewer { 
-        #[serde(default = "df_0_8")] zoom: f32, 
-        #[serde(default = "df_0_22")] corner_radius: f32 
+    StaticFade {
+        #[serde(default = "df_200")]
+        n_noise_pixels: f32,
+        #[serde(default = "df_0_8")]
+        static_luminosity: f32,
     },
-    Swap { 
-        #[serde(default = "df_0_4")] reflection: f32, 
-        #[serde(default = "df_0_2")] perspective: f32, 
-        #[serde(default = "df_3")] depth: f32 
+    StaticWipe {
+        #[serde(default = "df_true")]
+        up_to_down: bool,
+        #[serde(default = "df_0_5")]
+        max_static_span: f32,
+    },
+    StereoViewer {
+        #[serde(default = "df_0_8")]
+        zoom: f32,
+        #[serde(default = "df_0_22")]
+        corner_radius: f32,
+    },
+    Swap {
+        #[serde(default = "df_0_4")]
+        reflection: f32,
+        #[serde(default = "df_0_2")]
+        perspective: f32,
+        #[serde(default = "df_3")]
+        depth: f32,
     },
     Swirl,
     TangentMotionBlur,
     TopBottom,
-    TvStatic { #[serde(default = "df_0_05")] offset: f32 },
-    UndulatingBurnOut { 
-        #[serde(default = "df_0_03")] smoothness: f32, 
-        #[serde(default = "df_center")] center: [f32; 2], 
-        #[serde(default = "df_black_rgb")] color: [f32; 3] 
+    TvStatic {
+        #[serde(default = "df_0_05")]
+        offset: f32,
+    },
+    UndulatingBurnOut {
+        #[serde(default = "df_0_03")]
+        smoothness: f32,
+        #[serde(default = "df_center")]
+        center: [f32; 2],
+        #[serde(default = "df_black_rgb")]
+        color: [f32; 3],
     },
     VerticalClose,
     VerticalOpen,
-    WaterDrop { 
-        #[serde(default = "df_30")] amplitude: f32, 
-        #[serde(default = "df_30")] speed: f32 
+    WaterDrop {
+        #[serde(default = "df_30")]
+        amplitude: f32,
+        #[serde(default = "df_30")]
+        speed: f32,
     },
-    Wind { #[serde(default = "df_0_05")] size: f32 },
+    Wind {
+        #[serde(default = "df_0_05")]
+        size: f32,
+    },
     WindowBlinds,
-    WindowSlice { 
-        #[serde(default = "df_10")] count: f32, 
-        #[serde(default = "df_0_5")] smoothness: f32 
+    WindowSlice {
+        #[serde(default = "df_10")]
+        count: f32,
+        #[serde(default = "df_0_5")]
+        smoothness: f32,
     },
     WipeDown,
     WipeLeft,
@@ -333,20 +492,20 @@ pub enum Transition {
     WipeUp,
     XAxisTranslation,
     ZoomInCircles,
-    ZoomLeftWipe { #[serde(default = "df_0_8")] zoom_quickness: f32 },
-    ZoomRightWipe { #[serde(default = "df_0_8")] zoom_quickness: f32 },
-    Random,
-    Custom { 
-        shader: String, 
-        #[serde(default)]
-        params: HashMap<String, f32> 
+    ZoomLeftWipe {
+        #[serde(default = "df_0_8")]
+        zoom_quickness: f32,
     },
-}
-
-impl Default for Transition {
-    fn default() -> Self {
-        Transition::Fade
-    }
+    ZoomRightWipe {
+        #[serde(default = "df_0_8")]
+        zoom_quickness: f32,
+    },
+    Random,
+    Custom {
+        shader: String,
+        #[serde(default)]
+        params: HashMap<String, f32>,
+    },
 }
 
 impl Transition {
@@ -354,25 +513,106 @@ impl Transition {
         use rand::Rng;
         let mut rng = rand::thread_rng();
         let variants = [
-            "angular", "bookflip", "bounce", "bowtiehorizontal", "bowtievertical",
-            "bowtiewithparameter", "burn", "butterflywavescrawler", "cannabisleaf", "circle",
-            "circlecrop", "circleopen", "colorphase", "coord-from-in", "crazyparametricfun",
-            "colourdistance", "crosshatch", "crosswarp", "crosszoom", "cube", "directional",
-            "directionaleasing", "directionalscaled", "directionalwarp", "directionalwipe",
-            "displacement", "dissolve", "doom", "doorway", "dreamy", "dreamyzoom", "edge",
-            "fade", "fadecolor", "fadegrayscale", "filmburn", "flyeye", "glitchdisplace",
-            "glitchmemories", "gridflip", "heart", "hexagonalize", "horizontalclose",
-            "horizontalopen", "invertedpagecurl", "kaleidoscope", "leftright", "linearblur",
-            "luma", "luminancemelt", "morph", "mosaic", "mosaic_transition", "multiplyblend",
-            "overexposure", "perlin", "pinwheel", "pixelize", "polarfunction", "polkadotscurtain",
-            "powerkaleido", "radial", "randomnoisex", "randomsquares", "rectangle",
-            "rectanglecrop", "ripple", "rolls", "rotate", "rotatescalefade",
-            "rotatescalevanish", "scale_in", "simplezoom", "simplezoomout", "slides",
-            "squareswire", "squeeze", "staticfade", "static_wipe", "stereoviewer",
-            "swap", "swirl", "tangentmotionblur", "topbottom", "tvstatic",
-            "undulatingburnout", "verticalclose", "verticalopen", "waterdrop", "wind",
-            "windowblinds", "windowslice", "wipedown", "wipeleft", "wiperight", "wipeup",
-            "x-axis-translation", "zoomincircles", "zoomleftwipe", "zoomrightwipe",
+            "angular",
+            "bookflip",
+            "bounce",
+            "bowtiehorizontal",
+            "bowtievertical",
+            "bowtiewithparameter",
+            "burn",
+            "butterflywavescrawler",
+            "cannabisleaf",
+            "circle",
+            "circlecrop",
+            "circleopen",
+            "colorphase",
+            "coord-from-in",
+            "crazyparametricfun",
+            "colourdistance",
+            "crosshatch",
+            "crosswarp",
+            "crosszoom",
+            "cube",
+            "directional",
+            "directionaleasing",
+            "directionalscaled",
+            "directionalwarp",
+            "directionalwipe",
+            "displacement",
+            "dissolve",
+            "doom",
+            "doorway",
+            "dreamy",
+            "dreamyzoom",
+            "edge",
+            "fade",
+            "fadecolor",
+            "fadegrayscale",
+            "filmburn",
+            "flyeye",
+            "glitchdisplace",
+            "glitchmemories",
+            "gridflip",
+            "heart",
+            "hexagonalize",
+            "horizontalclose",
+            "horizontalopen",
+            "invertedpagecurl",
+            "kaleidoscope",
+            "leftright",
+            "linearblur",
+            "luma",
+            "luminancemelt",
+            "morph",
+            "mosaic",
+            "mosaic_transition",
+            "multiplyblend",
+            "overexposure",
+            "perlin",
+            "pinwheel",
+            "pixelize",
+            "polarfunction",
+            "polkadotscurtain",
+            "powerkaleido",
+            "radial",
+            "randomnoisex",
+            "randomsquares",
+            "rectangle",
+            "rectanglecrop",
+            "ripple",
+            "rolls",
+            "rotate",
+            "rotatescalefade",
+            "rotatescalevanish",
+            "scale_in",
+            "simplezoom",
+            "simplezoomout",
+            "slides",
+            "squareswire",
+            "squeeze",
+            "staticfade",
+            "static_wipe",
+            "stereoviewer",
+            "swap",
+            "swirl",
+            "tangentmotionblur",
+            "topbottom",
+            "tvstatic",
+            "undulatingburnout",
+            "verticalclose",
+            "verticalopen",
+            "waterdrop",
+            "wind",
+            "windowblinds",
+            "windowslice",
+            "wipedown",
+            "wipeleft",
+            "wiperight",
+            "wipeup",
+            "x-axis-translation",
+            "zoomincircles",
+            "zoomleftwipe",
+            "zoomrightwipe",
         ];
         let name = variants[rng.gen_range(0..variants.len())];
         Self::from_name(name)
@@ -380,105 +620,267 @@ impl Transition {
 
     pub fn from_name(name: &str) -> Self {
         match name.to_lowercase().as_str() {
-            "angular" => Transition::Angular { starting_angle: 0.0 },
+            "angular" => Transition::Angular {
+                starting_angle: 0.0,
+            },
             "bookflip" => Transition::BookFlip,
-            "bounce" => Transition::Bounce { shadow_colour: [0.0, 0.0, 0.0, 0.6], shadow_height: 0.075, bounces: 3.0 },
+            "bounce" => Transition::Bounce {
+                shadow_colour: [0.0, 0.0, 0.0, 0.6],
+                shadow_height: 0.075,
+                bounces: 3.0,
+            },
             "bowtiehorizontal" => Transition::BowTieHorizontal,
             "bowtievertical" => Transition::BowTieVertical,
-            "bowtiewithparameter" => Transition::BowTieWithParameter { adjust: 0.5, reverse: false },
+            "bowtiewithparameter" => Transition::BowTieWithParameter {
+                adjust: 0.5,
+                reverse: false,
+            },
             "burn" => Transition::Burn,
-            "butterflywavescrawler" => Transition::ButterflyWaveScrawler { amplitude: 1.0, waves: 30.0, color_separation: 0.3 },
+            "butterflywavescrawler" => Transition::ButterflyWaveScrawler {
+                amplitude: 1.0,
+                waves: 30.0,
+                color_separation: 0.3,
+            },
             "circle" => Transition::Circle,
-            "circlecrop" => Transition::CircleCrop { bgcolor: [0.0, 0.0, 0.0, 1.0] },
-            "circleopen" => Transition::CircleOpen { smoothness: 0.3, opening: true },
+            "circlecrop" => Transition::CircleCrop {
+                bgcolor: [0.0, 0.0, 0.0, 1.0],
+            },
+            "circleopen" => Transition::CircleOpen {
+                smoothness: 0.3,
+                opening: true,
+            },
             "colorphase" => Transition::ColorPhase,
             "coord-from-in" => Transition::CoordFromIn,
-            "crazyparametricfun" => Transition::CrazyParametricFun { a: 4.0, b: 1.0, amplitude: 120.0, smoothness: 0.1 },
+            "crazyparametricfun" => Transition::CrazyParametricFun {
+                a: 4.0,
+                b: 1.0,
+                amplitude: 120.0,
+                smoothness: 0.1,
+            },
             "colourdistance" => Transition::ColourDistance { power: 5.0 },
             "crosshatch" => Transition::CrossHatch,
             "crosswarp" => Transition::CrossWarp,
             "crosszoom" => Transition::CrossZoom { strength: 0.4 },
-            "cube" => Transition::Cube { persp: 0.7, unzoom: 0.3, reflection: 0.4, floating: 3.0 },
-            "directional" => Transition::Directional { direction: [0.0, 1.0] },
-            "directionaleasing" => Transition::DirectionalEasing { direction: [0.0, 1.0] },
-            "directionalscaled" => Transition::DirectionalScaled { direction: [0.0, 1.0], scale: 0.7 },
-            "directionalwarp" => Transition::DirectionalWarp { direction: [1.0, 0.0] },
-            "directionalwipe" | "wipe" => Transition::DirectionalWipe { direction: [1.0, -1.0], smoothness: 0.5 },
+            "cube" => Transition::Cube {
+                persp: 0.7,
+                unzoom: 0.3,
+                reflection: 0.4,
+                floating: 3.0,
+            },
+            "directional" => Transition::Directional {
+                direction: [0.0, 1.0],
+            },
+            "directionaleasing" => Transition::DirectionalEasing {
+                direction: [0.0, 1.0],
+            },
+            "directionalscaled" => Transition::DirectionalScaled {
+                direction: [0.0, 1.0],
+                scale: 0.7,
+            },
+            "directionalwarp" => Transition::DirectionalWarp {
+                direction: [1.0, 0.0],
+            },
+            "directionalwipe" | "wipe" => Transition::DirectionalWipe {
+                direction: [1.0, -1.0],
+                smoothness: 0.5,
+            },
             "displacement" => Transition::Displacement,
-            "dissolve" => Transition::Dissolve { line_width: 0.1, spread_clr: [1.0, 0.0, 0.0], hot_clr: [0.9, 0.9, 0.2], pow: 5.0, intensity: 1.0 },
-            "doom" => Transition::Doom { bars: 30, amplitude: 2.0, noise: 0.1, frequency: 0.5, drip_scale: 0.5 },
-            "doorway" => Transition::Doorway { reflection: 0.4, perspective: 0.4, depth: 3.0 },
+            "dissolve" => Transition::Dissolve {
+                line_width: 0.1,
+                spread_clr: [1.0, 0.0, 0.0],
+                hot_clr: [0.9, 0.9, 0.2],
+                pow: 5.0,
+                intensity: 1.0,
+            },
+            "doom" => Transition::Doom {
+                bars: 30,
+                amplitude: 2.0,
+                noise: 0.1,
+                frequency: 0.5,
+                drip_scale: 0.5,
+            },
+            "doorway" => Transition::Doorway {
+                reflection: 0.4,
+                perspective: 0.4,
+                depth: 3.0,
+            },
             "dreamy" => Transition::Dreamy,
-            "dreamyzoom" => Transition::DreamyZoom { rotation: 6.0, scale: 1.2 },
-            "edge" => Transition::Edge { thickness: 0.001, brightness: 8.0 },
+            "dreamyzoom" => Transition::DreamyZoom {
+                rotation: 6.0,
+                scale: 1.2,
+            },
+            "edge" => Transition::Edge {
+                thickness: 0.001,
+                brightness: 8.0,
+            },
             "fade" => Transition::Fade,
-            "fadecolor" => Transition::FadeColor { color: [0.0, 0.0, 0.0], color_phase: 0.4 },
+            "fadecolor" => Transition::FadeColor {
+                color: [0.0, 0.0, 0.0],
+                color_phase: 0.4,
+            },
             "fadegrayscale" => Transition::FadeGrayscale { intensity: 0.3 },
             "filmburn" => Transition::FilmBurn { seed: 2.31 },
-            "flyeye" => Transition::FlyEye { size: 0.04, zoom: 0.5, color_separation: 0.3 },
+            "flyeye" => Transition::FlyEye {
+                size: 0.04,
+                zoom: 0.5,
+                color_separation: 0.3,
+            },
             "glitchdisplace" => Transition::GlitchDisplace,
             "glitchmemories" => Transition::GlitchMemories,
-            "gridflip" => Transition::GridFlip { size: [4, 4], pause: 0.1, divider_width: 0.05, bgcolor: [0.0, 0.0, 0.0, 1.0], randomness: 0.1 },
+            "gridflip" => Transition::GridFlip {
+                size: [4, 4],
+                pause: 0.1,
+                divider_width: 0.05,
+                bgcolor: [0.0, 0.0, 0.0, 1.0],
+                randomness: 0.1,
+            },
             "heart" => Transition::Heart,
-            "hexagonalize" => Transition::Hexagonalize { steps: 50, horizontal_hexagons: 20.0 },
+            "hexagonalize" => Transition::Hexagonalize {
+                steps: 50,
+                horizontal_hexagons: 20.0,
+            },
             "horizontalclose" => Transition::HorizontalClose,
             "horizontalopen" => Transition::HorizontalOpen,
             "invertedpagecurl" => Transition::InvertedPageCurl,
-            "kaleidoscope" => Transition::Kaleidoscope { speed: 0.5, angle: 1.0, power: 0.3 },
+            "kaleidoscope" => Transition::Kaleidoscope {
+                speed: 0.5,
+                angle: 1.0,
+                power: 0.3,
+            },
             "leftright" => Transition::LeftRight,
             "linearblur" => Transition::LinearBlur { intensity: 0.1 },
             "luma" => Transition::Luma,
-            "luminancemelt" => Transition::LuminanceMelt { direction: true, luma_threshold: 0.05 },
+            "luminancemelt" => Transition::LuminanceMelt {
+                direction: true,
+                luma_threshold: 0.05,
+            },
             "morph" => Transition::Morph { strength: 0.1 },
             "mosaic" => Transition::Mosaic { endx: 2, endy: -1 },
             "mosaic_transition" => Transition::MosaicTransition { mosaic_num: 10.0 },
             "multiplyblend" => Transition::MultiplyBlend,
             "overexposure" => Transition::Overexposure,
-            "perlin" => Transition::Perlin { scale: 4.0, smoothness: 0.01, seed: 12.0 },
+            "perlin" => Transition::Perlin {
+                scale: 4.0,
+                smoothness: 0.01,
+                seed: 12.0,
+            },
             "pinwheel" => Transition::Pinwheel { speed: 2.0 },
-            "pixelize" => Transition::Pixelize { squares_min: [20, 20], steps: 50 },
+            "pixelize" => Transition::Pixelize {
+                squares_min: [20, 20],
+                steps: 50,
+            },
             "polarfunction" => Transition::PolarFunction { segments: 5 },
-            "polkadotscurtain" => Transition::PolkaDotsCurtain { dots: 20.0, center: [0.0, 0.0] },
-            "powerkaleido" => Transition::PowerKaleido { scale: 2.0, radius: 1.5, angle: 0.0 },
+            "polkadotscurtain" => Transition::PolkaDotsCurtain {
+                dots: 20.0,
+                center: [0.0, 0.0],
+            },
+            "powerkaleido" => Transition::PowerKaleido {
+                scale: 2.0,
+                radius: 1.5,
+                angle: 0.0,
+            },
             "radial" => Transition::Radial { smoothness: 1.0 },
             "randomnoisex" => Transition::RandomNoiseX,
-            "randomsquares" => Transition::RandomSquares { size: [10, 10], smoothness: 0.5 },
-            "rectangle" => Transition::Rectangle { bgcolor: [0.0, 0.0, 0.0, 1.0] },
-            "rectanglecrop" => Transition::RectangleCrop { bgcolor: [0.0, 0.0, 0.0, 1.0] },
-            "ripple" => Transition::Ripple { amplitude: 100.0, speed: 50.0 },
-            "rolls" => Transition::Rolls { rolls_type: 0, rot_down: false },
+            "randomsquares" => Transition::RandomSquares {
+                size: [10, 10],
+                smoothness: 0.5,
+            },
+            "rectangle" => Transition::Rectangle {
+                bgcolor: [0.0, 0.0, 0.0, 1.0],
+            },
+            "rectanglecrop" => Transition::RectangleCrop {
+                bgcolor: [0.0, 0.0, 0.0, 1.0],
+            },
+            "ripple" => Transition::Ripple {
+                amplitude: 100.0,
+                speed: 50.0,
+            },
+            "rolls" => Transition::Rolls {
+                rolls_type: 0,
+                rot_down: false,
+            },
             "rotate" => Transition::Rotate,
-            "rotatescalefade" => Transition::RotateScaleFade { center: [0.5, 0.5], rotations: 1.0, scale: 8.0, back_color: [0.15, 0.15, 0.15, 1.0] },
-            "rotatescalevanish" => Transition::RotateScaleVanish { fade_in_second: true, reverse_effect: false, reverse_rotation: false },
+            "rotatescalefade" => Transition::RotateScaleFade {
+                center: [0.5, 0.5],
+                rotations: 1.0,
+                scale: 8.0,
+                back_color: [0.15, 0.15, 0.15, 1.0],
+            },
+            "rotatescalevanish" => Transition::RotateScaleVanish {
+                fade_in_second: true,
+                reverse_effect: false,
+                reverse_rotation: false,
+            },
             "scale_in" => Transition::ScaleIn,
-            "simplezoom" => Transition::SimpleZoom { zoom_quickness: 0.8 },
-            "simplezoomout" => Transition::SimpleZoomOut { zoom_quickness: 0.8, fade_edge: true },
-            "slides" => Transition::Slides { slides_type: 0, slides_in: false },
-            "squareswire" => Transition::SquaresWire { squares: [10, 10], direction: [1.0, -0.5], smoothness: 1.6 },
-            "squeeze" => Transition::Squeeze { color_separation: 0.1 },
-            "staticfade" => Transition::StaticFade { n_noise_pixels: 200.0, static_luminosity: 0.8 },
-            "static_wipe" => Transition::StaticWipe { up_to_down: true, max_static_span: 0.5 },
-            "stereoviewer" => Transition::StereoViewer { zoom: 0.88, corner_radius: 0.22 },
-            "swap" => Transition::Swap { reflection: 0.4, perspective: 0.2, depth: 3.0 },
+            "simplezoom" => Transition::SimpleZoom {
+                zoom_quickness: 0.8,
+            },
+            "simplezoomout" => Transition::SimpleZoomOut {
+                zoom_quickness: 0.8,
+                fade_edge: true,
+            },
+            "slides" => Transition::Slides {
+                slides_type: 0,
+                slides_in: false,
+            },
+            "squareswire" => Transition::SquaresWire {
+                squares: [10, 10],
+                direction: [1.0, -0.5],
+                smoothness: 1.6,
+            },
+            "squeeze" => Transition::Squeeze {
+                color_separation: 0.1,
+            },
+            "staticfade" => Transition::StaticFade {
+                n_noise_pixels: 200.0,
+                static_luminosity: 0.8,
+            },
+            "static_wipe" => Transition::StaticWipe {
+                up_to_down: true,
+                max_static_span: 0.5,
+            },
+            "stereoviewer" => Transition::StereoViewer {
+                zoom: 0.88,
+                corner_radius: 0.22,
+            },
+            "swap" => Transition::Swap {
+                reflection: 0.4,
+                perspective: 0.2,
+                depth: 3.0,
+            },
             "swirl" => Transition::Swirl,
             "tangentmotionblur" => Transition::TangentMotionBlur,
             "topbottom" => Transition::TopBottom,
             "tvstatic" => Transition::TvStatic { offset: 0.05 },
-            "undulatingburnout" => Transition::UndulatingBurnOut { smoothness: 0.03, center: [0.5, 0.5], color: [0.0, 0.0, 0.0] },
+            "undulatingburnout" => Transition::UndulatingBurnOut {
+                smoothness: 0.03,
+                center: [0.5, 0.5],
+                color: [0.0, 0.0, 0.0],
+            },
             "verticalclose" => Transition::VerticalClose,
             "verticalopen" => Transition::VerticalOpen,
-            "waterdrop" => Transition::WaterDrop { amplitude: 30.0, speed: 30.0 },
+            "waterdrop" => Transition::WaterDrop {
+                amplitude: 30.0,
+                speed: 30.0,
+            },
             "wind" => Transition::Wind { size: 0.05 },
             "windowblinds" => Transition::WindowBlinds,
-            "windowslice" => Transition::WindowSlice { count: 10.0, smoothness: 0.5 },
+            "windowslice" => Transition::WindowSlice {
+                count: 10.0,
+                smoothness: 0.5,
+            },
             "wipedown" => Transition::WipeDown,
             "wipeleft" => Transition::WipeLeft,
             "wiperight" => Transition::WipeRight,
             "wipeup" => Transition::WipeUp,
             "x-axis-translation" => Transition::XAxisTranslation,
             "zoomincircles" => Transition::ZoomInCircles,
-            "zoomleftwipe" => Transition::ZoomLeftWipe { zoom_quickness: 0.8 },
-            "zoomrightwipe" => Transition::ZoomRightWipe { zoom_quickness: 0.8 },
+            "zoomleftwipe" => Transition::ZoomLeftWipe {
+                zoom_quickness: 0.8,
+            },
+            "zoomrightwipe" => Transition::ZoomRightWipe {
+                zoom_quickness: 0.8,
+            },
             "random" => Transition::Random,
             _ => Transition::Fade,
         }
@@ -594,153 +996,406 @@ impl Transition {
     pub fn to_params(&self) -> [f32; 28] {
         let mut p = [0.0; 28];
         match self {
-            Transition::BookFlip | Transition::Burn | Transition::CannabisLeaf | Transition::Circle | Transition::ColorPhase | Transition::CoordFromIn | Transition::CrossHatch | Transition::CrossWarp | Transition::Displacement | Transition::Dreamy | Transition::Fade | Transition::GlitchDisplace | Transition::GlitchMemories | Transition::Heart | Transition::HorizontalClose | Transition::HorizontalOpen | Transition::InvertedPageCurl | Transition::LeftRight | Transition::Luma | Transition::MultiplyBlend | Transition::Overexposure | Transition::RandomNoiseX | Transition::Rotate | Transition::ScaleIn | Transition::Swirl | Transition::TangentMotionBlur | Transition::TopBottom | Transition::VerticalClose | Transition::VerticalOpen | Transition::WipeDown | Transition::WipeLeft | Transition::WipeRight | Transition::WipeUp | Transition::WindowBlinds | Transition::XAxisTranslation | Transition::ZoomInCircles | Transition::Random => {}
-            Transition::Angular { starting_angle } => { p[0] = *starting_angle; }
+            Transition::BookFlip
+            | Transition::Burn
+            | Transition::CannabisLeaf
+            | Transition::Circle
+            | Transition::ColorPhase
+            | Transition::CoordFromIn
+            | Transition::CrossHatch
+            | Transition::CrossWarp
+            | Transition::Displacement
+            | Transition::Dreamy
+            | Transition::Fade
+            | Transition::GlitchDisplace
+            | Transition::GlitchMemories
+            | Transition::Heart
+            | Transition::HorizontalClose
+            | Transition::HorizontalOpen
+            | Transition::InvertedPageCurl
+            | Transition::LeftRight
+            | Transition::Luma
+            | Transition::MultiplyBlend
+            | Transition::Overexposure
+            | Transition::RandomNoiseX
+            | Transition::Rotate
+            | Transition::ScaleIn
+            | Transition::Swirl
+            | Transition::TangentMotionBlur
+            | Transition::TopBottom
+            | Transition::VerticalClose
+            | Transition::VerticalOpen
+            | Transition::WipeDown
+            | Transition::WipeLeft
+            | Transition::WipeRight
+            | Transition::WipeUp
+            | Transition::WindowBlinds
+            | Transition::XAxisTranslation
+            | Transition::ZoomInCircles
+            | Transition::Random => {}
+            Transition::Angular { starting_angle } => {
+                p[0] = *starting_angle;
+            }
             Transition::BowTieWithParameter { adjust, reverse } => {
-                p[0] = *adjust; p[1] = if *reverse { 1.0 } else { 0.0 };
+                p[0] = *adjust;
+                p[1] = if *reverse { 1.0 } else { 0.0 };
             }
             Transition::BowTieHorizontal | Transition::BowTieVertical => {}
-            Transition::Bounce { shadow_colour, shadow_height, bounces } => {
+            Transition::Bounce {
+                shadow_colour,
+                shadow_height,
+                bounces,
+            } => {
                 p[0..4].copy_from_slice(shadow_colour);
                 p[4] = *shadow_height;
                 p[5] = *bounces;
             }
-            Transition::ButterflyWaveScrawler { amplitude, waves, color_separation } => {
-                p[0] = *amplitude; p[1] = *waves; p[2] = *color_separation;
+            Transition::ButterflyWaveScrawler {
+                amplitude,
+                waves,
+                color_separation,
+            } => {
+                p[0] = *amplitude;
+                p[1] = *waves;
+                p[2] = *color_separation;
             }
-            Transition::CircleCrop { bgcolor } => { p[0..4].copy_from_slice(bgcolor); }
-            Transition::CircleOpen { smoothness, opening } => {
+            Transition::CircleCrop { bgcolor } => {
+                p[0..4].copy_from_slice(bgcolor);
+            }
+            Transition::CircleOpen {
+                smoothness,
+                opening,
+            } => {
                 p[0] = *smoothness;
                 p[1] = if *opening { 1.0 } else { 0.0 };
             }
-            Transition::CrazyParametricFun { a, b, amplitude, smoothness } => {
-                p[0] = *a; p[1] = *b; p[2] = *amplitude; p[3] = *smoothness;
+            Transition::CrazyParametricFun {
+                a,
+                b,
+                amplitude,
+                smoothness,
+            } => {
+                p[0] = *a;
+                p[1] = *b;
+                p[2] = *amplitude;
+                p[3] = *smoothness;
             }
-            Transition::ColourDistance { power } => { p[0] = *power; }
-            Transition::CrossZoom { strength } => { p[0] = *strength; }
-            Transition::Cube { persp, unzoom, reflection, floating } => {
-                p[0] = *persp; p[1] = *unzoom; p[2] = *reflection; p[3] = *floating;
+            Transition::ColourDistance { power } => {
+                p[0] = *power;
             }
-            Transition::Directional { direction } => { p[0..2].copy_from_slice(direction); }
-            Transition::DirectionalEasing { direction } => { p[0..2].copy_from_slice(direction); }
+            Transition::CrossZoom { strength } => {
+                p[0] = *strength;
+            }
+            Transition::Cube {
+                persp,
+                unzoom,
+                reflection,
+                floating,
+            } => {
+                p[0] = *persp;
+                p[1] = *unzoom;
+                p[2] = *reflection;
+                p[3] = *floating;
+            }
+            Transition::Directional { direction } => {
+                p[0..2].copy_from_slice(direction);
+            }
+            Transition::DirectionalEasing { direction } => {
+                p[0..2].copy_from_slice(direction);
+            }
             Transition::DirectionalScaled { direction, scale } => {
-                p[0..2].copy_from_slice(direction); p[2] = *scale;
+                p[0..2].copy_from_slice(direction);
+                p[2] = *scale;
             }
-            Transition::DirectionalWarp { direction } => { p[0..2].copy_from_slice(direction); }
-            Transition::DirectionalWipe { direction, smoothness } => {
-                p[0..2].copy_from_slice(direction); p[2] = *smoothness;
+            Transition::DirectionalWarp { direction } => {
+                p[0..2].copy_from_slice(direction);
             }
-            Transition::Dissolve { line_width, spread_clr, hot_clr, pow, intensity } => {
+            Transition::DirectionalWipe {
+                direction,
+                smoothness,
+            } => {
+                p[0..2].copy_from_slice(direction);
+                p[2] = *smoothness;
+            }
+            Transition::Dissolve {
+                line_width,
+                spread_clr,
+                hot_clr,
+                pow,
+                intensity,
+            } => {
                 p[0] = *line_width;
                 p[1..4].copy_from_slice(spread_clr);
                 p[4..7].copy_from_slice(hot_clr);
                 p[7] = *pow;
                 p[8] = *intensity;
             }
-            Transition::Doom { bars, amplitude, noise, frequency, drip_scale } => {
-                p[0] = *bars as f32; p[1] = *amplitude; p[2] = *noise; p[3] = *frequency; p[4] = *drip_scale;
+            Transition::Doom {
+                bars,
+                amplitude,
+                noise,
+                frequency,
+                drip_scale,
+            } => {
+                p[0] = *bars as f32;
+                p[1] = *amplitude;
+                p[2] = *noise;
+                p[3] = *frequency;
+                p[4] = *drip_scale;
             }
-            Transition::Doorway { reflection, perspective, depth } => {
-                p[0] = *reflection; p[1] = *perspective; p[2] = *depth;
+            Transition::Doorway {
+                reflection,
+                perspective,
+                depth,
+            } => {
+                p[0] = *reflection;
+                p[1] = *perspective;
+                p[2] = *depth;
             }
-            Transition::DreamyZoom { rotation, scale } => { p[0] = *rotation; p[1] = *scale; }
-            Transition::Edge { thickness, brightness } => { p[0] = *thickness; p[1] = *brightness; }
+            Transition::DreamyZoom { rotation, scale } => {
+                p[0] = *rotation;
+                p[1] = *scale;
+            }
+            Transition::Edge {
+                thickness,
+                brightness,
+            } => {
+                p[0] = *thickness;
+                p[1] = *brightness;
+            }
             Transition::FadeColor { color, color_phase } => {
-                p[0..3].copy_from_slice(color); p[3] = *color_phase;
+                p[0..3].copy_from_slice(color);
+                p[3] = *color_phase;
             }
-            Transition::FadeGrayscale { intensity } => { p[0] = *intensity; }
-            Transition::FlyEye { size, zoom, color_separation } => {
-                p[0] = *size; p[1] = *zoom; p[2] = *color_separation;
+            Transition::FadeGrayscale { intensity } => {
+                p[0] = *intensity;
             }
-            Transition::GridFlip { size, pause, divider_width, bgcolor, randomness } => {
-                p[0] = size[0] as f32; p[1] = size[1] as f32;
-                p[2] = *pause; p[3] = *divider_width;
-                p[4..8].copy_from_slice(bgcolor); p[8] = *randomness;
+            Transition::FlyEye {
+                size,
+                zoom,
+                color_separation,
+            } => {
+                p[0] = *size;
+                p[1] = *zoom;
+                p[2] = *color_separation;
             }
-            Transition::Hexagonalize { steps, horizontal_hexagons } => {
-                p[0] = *steps as f32; p[1] = *horizontal_hexagons;
+            Transition::GridFlip {
+                size,
+                pause,
+                divider_width,
+                bgcolor,
+                randomness,
+            } => {
+                p[0] = size[0] as f32;
+                p[1] = size[1] as f32;
+                p[2] = *pause;
+                p[3] = *divider_width;
+                p[4..8].copy_from_slice(bgcolor);
+                p[8] = *randomness;
             }
-            Transition::Kaleidoscope { speed, angle, power } => {
-                p[0] = *speed; p[1] = *angle; p[2] = *power;
+            Transition::Hexagonalize {
+                steps,
+                horizontal_hexagons,
+            } => {
+                p[0] = *steps as f32;
+                p[1] = *horizontal_hexagons;
             }
-            Transition::LinearBlur { intensity } => { p[0] = *intensity; }
-            Transition::LuminanceMelt { direction, luma_threshold } => {
-                p[0] = if *direction { 1.0 } else { 0.0 }; p[1] = *luma_threshold;
+            Transition::Kaleidoscope {
+                speed,
+                angle,
+                power,
+            } => {
+                p[0] = *speed;
+                p[1] = *angle;
+                p[2] = *power;
             }
-            Transition::Morph { strength } => { p[0] = *strength; }
-            Transition::Mosaic { endx, endy } => { p[0] = *endx as f32; p[1] = *endy as f32; }
-            Transition::MosaicTransition { mosaic_num } => { p[0] = *mosaic_num; }
-            Transition::Perlin { scale, smoothness, seed } => {
-                p[0] = *scale; p[1] = *smoothness; p[2] = *seed;
+            Transition::LinearBlur { intensity } => {
+                p[0] = *intensity;
             }
-            Transition::Pinwheel { speed } => { p[0] = *speed; }
+            Transition::LuminanceMelt {
+                direction,
+                luma_threshold,
+            } => {
+                p[0] = if *direction { 1.0 } else { 0.0 };
+                p[1] = *luma_threshold;
+            }
+            Transition::Morph { strength } => {
+                p[0] = *strength;
+            }
+            Transition::Mosaic { endx, endy } => {
+                p[0] = *endx as f32;
+                p[1] = *endy as f32;
+            }
+            Transition::MosaicTransition { mosaic_num } => {
+                p[0] = *mosaic_num;
+            }
+            Transition::Perlin {
+                scale,
+                smoothness,
+                seed,
+            } => {
+                p[0] = *scale;
+                p[1] = *smoothness;
+                p[2] = *seed;
+            }
+            Transition::Pinwheel { speed } => {
+                p[0] = *speed;
+            }
             Transition::Pixelize { squares_min, steps } => {
-                p[0] = squares_min[0] as f32; p[1] = squares_min[1] as f32; p[2] = *steps as f32;
+                p[0] = squares_min[0] as f32;
+                p[1] = squares_min[1] as f32;
+                p[2] = *steps as f32;
             }
-            Transition::PolarFunction { segments } => { p[0] = *segments as f32; }
+            Transition::PolarFunction { segments } => {
+                p[0] = *segments as f32;
+            }
             Transition::PolkaDotsCurtain { dots, center } => {
-                p[0] = *dots; p[1..3].copy_from_slice(center);
+                p[0] = *dots;
+                p[1..3].copy_from_slice(center);
             }
-            Transition::PowerKaleido { scale, radius, angle } => {
-                p[0] = *scale; p[1] = *radius; p[2] = *angle;
+            Transition::PowerKaleido {
+                scale,
+                radius,
+                angle,
+            } => {
+                p[0] = *scale;
+                p[1] = *radius;
+                p[2] = *angle;
             }
-            Transition::Radial { smoothness } => { p[0] = *smoothness; }
+            Transition::Radial { smoothness } => {
+                p[0] = *smoothness;
+            }
             Transition::RandomSquares { size, smoothness } => {
-                p[0] = size[0] as f32; p[1] = size[1] as f32; p[2] = *smoothness;
+                p[0] = size[0] as f32;
+                p[1] = size[1] as f32;
+                p[2] = *smoothness;
             }
-            Transition::Rectangle { bgcolor } => { p[0..4].copy_from_slice(bgcolor); }
-            Transition::RectangleCrop { bgcolor } => { p[0..4].copy_from_slice(bgcolor); }
-            Transition::Ripple { amplitude, speed } => { p[0] = *amplitude; p[1] = *speed; }
-            Transition::Rolls { rolls_type, rot_down } => {
-                p[0] = *rolls_type as f32; p[1] = if *rot_down { 1.0 } else { 0.0 };
+            Transition::Rectangle { bgcolor } => {
+                p[0..4].copy_from_slice(bgcolor);
             }
-            Transition::RotateScaleFade { center, rotations, scale, back_color } => {
-                p[0..2].copy_from_slice(center); p[2] = *rotations; p[3] = *scale;
+            Transition::RectangleCrop { bgcolor } => {
+                p[0..4].copy_from_slice(bgcolor);
+            }
+            Transition::Ripple { amplitude, speed } => {
+                p[0] = *amplitude;
+                p[1] = *speed;
+            }
+            Transition::Rolls {
+                rolls_type,
+                rot_down,
+            } => {
+                p[0] = *rolls_type as f32;
+                p[1] = if *rot_down { 1.0 } else { 0.0 };
+            }
+            Transition::RotateScaleFade {
+                center,
+                rotations,
+                scale,
+                back_color,
+            } => {
+                p[0..2].copy_from_slice(center);
+                p[2] = *rotations;
+                p[3] = *scale;
                 p[4..8].copy_from_slice(back_color);
             }
-            Transition::RotateScaleVanish { fade_in_second, reverse_effect, reverse_rotation } => {
+            Transition::RotateScaleVanish {
+                fade_in_second,
+                reverse_effect,
+                reverse_rotation,
+            } => {
                 p[0] = if *fade_in_second { 1.0 } else { 0.0 };
                 p[1] = if *reverse_effect { 1.0 } else { 0.0 };
                 p[2] = if *reverse_rotation { 1.0 } else { 0.0 };
             }
-            Transition::SimpleZoom { zoom_quickness } => { p[0] = *zoom_quickness; }
-            Transition::SimpleZoomOut { zoom_quickness, fade_edge } => {
-                p[0] = *zoom_quickness; p[1] = if *fade_edge { 1.0 } else { 0.0 };
+            Transition::SimpleZoom { zoom_quickness } => {
+                p[0] = *zoom_quickness;
             }
-            Transition::Slides { slides_type, slides_in } => {
-                p[0] = *slides_type as f32; p[1] = if *slides_in { 1.0 } else { 0.0 };
+            Transition::SimpleZoomOut {
+                zoom_quickness,
+                fade_edge,
+            } => {
+                p[0] = *zoom_quickness;
+                p[1] = if *fade_edge { 1.0 } else { 0.0 };
             }
-            Transition::SquaresWire { squares, direction, smoothness } => {
-                p[0] = squares[0] as f32; p[1] = squares[1] as f32;
-                p[2] = direction[0]; p[3] = direction[1];
+            Transition::Slides {
+                slides_type,
+                slides_in,
+            } => {
+                p[0] = *slides_type as f32;
+                p[1] = if *slides_in { 1.0 } else { 0.0 };
+            }
+            Transition::SquaresWire {
+                squares,
+                direction,
+                smoothness,
+            } => {
+                p[0] = squares[0] as f32;
+                p[1] = squares[1] as f32;
+                p[2] = direction[0];
+                p[3] = direction[1];
                 p[4] = *smoothness;
             }
-            Transition::Squeeze { color_separation } => { p[0] = *color_separation; }
-            Transition::StaticFade { n_noise_pixels, static_luminosity } => {
-                p[0] = *n_noise_pixels; p[1] = *static_luminosity;
+            Transition::Squeeze { color_separation } => {
+                p[0] = *color_separation;
             }
-            Transition::StaticWipe { up_to_down, max_static_span } => {
-                p[0] = if *up_to_down { 1.0 } else { 0.0 }; p[1] = *max_static_span;
+            Transition::StaticFade {
+                n_noise_pixels,
+                static_luminosity,
+            } => {
+                p[0] = *n_noise_pixels;
+                p[1] = *static_luminosity;
             }
-            Transition::StereoViewer { zoom, corner_radius } => {
-                p[0] = *zoom; p[1] = *corner_radius;
+            Transition::StaticWipe {
+                up_to_down,
+                max_static_span,
+            } => {
+                p[0] = if *up_to_down { 1.0 } else { 0.0 };
+                p[1] = *max_static_span;
             }
-            Transition::Swap { reflection, perspective, depth } => {
-                p[0] = *reflection; p[1] = *perspective; p[2] = *depth;
+            Transition::StereoViewer {
+                zoom,
+                corner_radius,
+            } => {
+                p[0] = *zoom;
+                p[1] = *corner_radius;
             }
-            Transition::TvStatic { offset } => { p[0] = *offset; }
-            Transition::UndulatingBurnOut { smoothness, center, color } => {
-                p[0] = *smoothness; p[1..3].copy_from_slice(center); p[3..6].copy_from_slice(color);
+            Transition::Swap {
+                reflection,
+                perspective,
+                depth,
+            } => {
+                p[0] = *reflection;
+                p[1] = *perspective;
+                p[2] = *depth;
             }
-            Transition::WaterDrop { amplitude, speed } => { p[0] = *amplitude; p[1] = *speed; }
-            Transition::Wind { size } => { p[0] = *size; }
+            Transition::TvStatic { offset } => {
+                p[0] = *offset;
+            }
+            Transition::UndulatingBurnOut {
+                smoothness,
+                center,
+                color,
+            } => {
+                p[0] = *smoothness;
+                p[1..3].copy_from_slice(center);
+                p[3..6].copy_from_slice(color);
+            }
+            Transition::WaterDrop { amplitude, speed } => {
+                p[0] = *amplitude;
+                p[1] = *speed;
+            }
+            Transition::Wind { size } => {
+                p[0] = *size;
+            }
             Transition::Custom { .. } => {
                 // Named parameters handled via #define in daemon for Custom
             }
             Transition::WindowSlice { count, smoothness } => {
-                p[0] = *count; p[1] = *smoothness;
+                p[0] = *count;
+                p[1] = *smoothness;
             }
-            Transition::ZoomLeftWipe { zoom_quickness } | Transition::ZoomRightWipe { zoom_quickness } => {
+            Transition::ZoomLeftWipe { zoom_quickness }
+            | Transition::ZoomRightWipe { zoom_quickness } => {
                 p[0] = *zoom_quickness;
             }
             _ => {}
@@ -780,60 +1435,174 @@ fn default_radial_smoothness() -> f32 {
     1.0
 }
 
-fn df_0() -> f32 { 0.0 }
-fn df_0_075() -> f32 { 0.075 }
-fn df_3() -> f32 { 3.0 }
-fn df_1() -> f32 { 1.0 }
-fn df_30() -> f32 { 30.0 }
-fn df_0_3() -> f32 { 0.3 }
-fn df_black_rgba() -> [f32; 4] { [0.0, 0.0, 0.0, 1.0] }
-fn df_black_alpha() -> [f32; 4] { [0.0, 0.0, 0.0, 0.6] }
-fn df_true() -> bool { true }
-fn df_5() -> f32 { 5.0 }
-fn df_0_4() -> f32 { 0.4 }
-fn df_0_7() -> f32 { 0.7 }
-fn df_y_up() -> [f32; 2] { [0.0, 1.0] }
-fn df_0_1() -> f32 { 0.1 }
-fn df_red() -> [f32; 3] { [1.0, 0.0, 0.0] }
-fn df_yellow() -> [f32; 3] { [0.9, 0.9, 0.2] }
-fn df_2() -> f32 { 2.0 }
-fn df_6() -> f32 { 6.0 }
-fn df_1_2() -> f32 { 1.2 }
-fn df_tiny() -> f32 { 0.001 }
-fn df_8() -> f32 { 8.0 }
-fn df_black_rgb() -> [f32; 3] { [0.0, 0.0, 0.0] }
-fn df_2_31() -> f32 { 2.31 }
-fn df_0_04() -> f32 { 0.04 }
-fn df_0_5() -> f32 { 0.5 }
-fn df_4_4() -> [i32; 2] { [4, 4] }
-fn df_0_05() -> f32 { 0.05 }
-fn df_50_i() -> i32 { 50 }
-fn df_20() -> f32 { 20.0 }
-fn df_0_05_f() -> f32 { 0.05 }
-fn df_2_i() -> i32 { 2 }
-fn df_neg_1_i() -> i32 { -1 }
-fn df_4() -> f32 { 4.0 }
-fn df_0_01() -> f32 { 0.01 }
-fn df_12() -> f32 { 12.0 }
-fn df_20_20() -> [i32; 2] { [20, 20] }
-fn df_5_i() -> i32 { 5 }
-fn df_center() -> [f32; 2] { [0.5, 0.5] }
-fn df_origin() -> [f32; 2] { [0.0, 0.0] }
-fn df_1_5() -> f32 { 1.5 }
-fn df_10_10() -> [i32; 2] { [10, 10] }
-fn df_100() -> f32 { 100.0 }
-fn df_50_f() -> f32 { 50.0 }
-fn df_0_i() -> i32 { 0 }
-fn df_false() -> bool { false }
-fn df_8_f() -> f32 { 8.0 }
-fn df_dark_grey() -> [f32; 4] { [0.15, 0.15, 0.15, 1.0] }
-fn df_0_8() -> f32 { 0.8 }
-fn df_200() -> f32 { 200.0 }
-fn df_0_2() -> f32 { 0.2 }
-fn df_0_22() -> f32 { 0.22 }
-fn df_30_i() -> i32 { 30 }
-fn df_10() -> f32 { 10.0 }
-fn df_x_up() -> [f32; 2] { [1.0, 0.0] }
-fn df_120() -> f32 { 120.0 }
-fn df_1_6() -> f32 { 1.6 }
-fn df_0_03() -> f32 { 0.03 }
+fn df_0() -> f32 {
+    0.0
+}
+fn df_0_075() -> f32 {
+    0.075
+}
+fn df_3() -> f32 {
+    3.0
+}
+fn df_1() -> f32 {
+    1.0
+}
+fn df_30() -> f32 {
+    30.0
+}
+fn df_0_3() -> f32 {
+    0.3
+}
+fn df_black_rgba() -> [f32; 4] {
+    [0.0, 0.0, 0.0, 1.0]
+}
+fn df_black_alpha() -> [f32; 4] {
+    [0.0, 0.0, 0.0, 0.6]
+}
+fn df_true() -> bool {
+    true
+}
+fn df_5() -> f32 {
+    5.0
+}
+fn df_0_4() -> f32 {
+    0.4
+}
+fn df_0_7() -> f32 {
+    0.7
+}
+fn df_y_up() -> [f32; 2] {
+    [0.0, 1.0]
+}
+fn df_0_1() -> f32 {
+    0.1
+}
+fn df_red() -> [f32; 3] {
+    [1.0, 0.0, 0.0]
+}
+fn df_yellow() -> [f32; 3] {
+    [0.9, 0.9, 0.2]
+}
+fn df_2() -> f32 {
+    2.0
+}
+fn df_6() -> f32 {
+    6.0
+}
+fn df_1_2() -> f32 {
+    1.2
+}
+fn df_tiny() -> f32 {
+    0.001
+}
+fn df_8() -> f32 {
+    8.0
+}
+fn df_black_rgb() -> [f32; 3] {
+    [0.0, 0.0, 0.0]
+}
+fn df_2_31() -> f32 {
+    2.31
+}
+fn df_0_04() -> f32 {
+    0.04
+}
+fn df_0_5() -> f32 {
+    0.5
+}
+fn df_4_4() -> [i32; 2] {
+    [4, 4]
+}
+fn df_0_05() -> f32 {
+    0.05
+}
+fn df_50_i() -> i32 {
+    50
+}
+fn df_20() -> f32 {
+    20.0
+}
+fn df_0_05_f() -> f32 {
+    0.05
+}
+fn df_2_i() -> i32 {
+    2
+}
+fn df_neg_1_i() -> i32 {
+    -1
+}
+fn df_4() -> f32 {
+    4.0
+}
+fn df_0_01() -> f32 {
+    0.01
+}
+fn df_12() -> f32 {
+    12.0
+}
+fn df_20_20() -> [i32; 2] {
+    [20, 20]
+}
+fn df_5_i() -> i32 {
+    5
+}
+fn df_center() -> [f32; 2] {
+    [0.5, 0.5]
+}
+fn df_origin() -> [f32; 2] {
+    [0.0, 0.0]
+}
+fn df_1_5() -> f32 {
+    1.5
+}
+fn df_10_10() -> [i32; 2] {
+    [10, 10]
+}
+fn df_100() -> f32 {
+    100.0
+}
+fn df_50_f() -> f32 {
+    50.0
+}
+fn df_0_i() -> i32 {
+    0
+}
+fn df_false() -> bool {
+    false
+}
+fn df_8_f() -> f32 {
+    8.0
+}
+fn df_dark_grey() -> [f32; 4] {
+    [0.15, 0.15, 0.15, 1.0]
+}
+fn df_0_8() -> f32 {
+    0.8
+}
+fn df_200() -> f32 {
+    200.0
+}
+fn df_0_2() -> f32 {
+    0.2
+}
+fn df_0_22() -> f32 {
+    0.22
+}
+fn df_30_i() -> i32 {
+    30
+}
+fn df_10() -> f32 {
+    10.0
+}
+fn df_x_up() -> [f32; 2] {
+    [1.0, 0.0]
+}
+fn df_120() -> f32 {
+    120.0
+}
+fn df_1_6() -> f32 {
+    1.6
+}
+fn df_0_03() -> f32 {
+    0.03
+}

--- a/kaleidux-daemon/src/cache.rs
+++ b/kaleidux-daemon/src/cache.rs
@@ -1,10 +1,10 @@
-use std::path::{Path, PathBuf};
-use std::time::UNIX_EPOCH;
-use anyhow::{Result, Context};
-use serde::{Serialize, Deserialize};
+use anyhow::{Context, Result};
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use redb::{Database, ReadableTable, TableDefinition};
-use notify::{Watcher, RecommendedWatcher, RecursiveMode, Event, EventKind};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::UNIX_EPOCH;
 use tokio::sync::mpsc;
 
 // Table definitions for redb
@@ -17,7 +17,7 @@ const BLACKLIST_TABLE: TableDefinition<&[u8], bool> = TableDefinition::new("blac
 pub struct FileMetadata {
     pub mtime: u64, // Unix timestamp
     pub size: u64,
-    pub content_type: u8, // 0 = Image, 1 = Video
+    pub content_type: u8,   // 0 = Image, 1 = Video
     pub discovered_at: u64, // Unix timestamp
 }
 
@@ -31,10 +31,10 @@ impl FileCache {
             .context("Failed to get cache directory")?
             .join("kaleidux");
         std::fs::create_dir_all(&cache_dir)?;
-        
+
         let db_path = cache_dir.join("cache.redb");
         let db = Database::create(&db_path)?;
-        
+
         // Initialize tables
         let write_txn = db.begin_write()?;
         {
@@ -44,14 +44,14 @@ impl FileCache {
             let _ = write_txn.open_table(BLACKLIST_TABLE)?;
         }
         write_txn.commit()?;
-        
+
         Ok(Self { db })
     }
 
     pub fn get_file_metadata(&self, path: &Path) -> Result<Option<FileMetadata>> {
         let read_txn = self.db.begin_read()?;
         let table = read_txn.open_table(FILE_CACHE_TABLE)?;
-        
+
         let path_str = path.to_string_lossy();
         let path_bytes = path_str.as_bytes();
         if let Some(data) = table.get(path_bytes)? {
@@ -77,11 +77,8 @@ impl FileCache {
 
     pub fn is_file_valid(&self, path: &Path) -> Result<bool> {
         let metadata = std::fs::metadata(path)?;
-        let mtime = metadata
-            .modified()?
-            .duration_since(UNIX_EPOCH)?
-            .as_secs();
-        
+        let mtime = metadata.modified()?.duration_since(UNIX_EPOCH)?.as_secs();
+
         if let Some(cached) = self.get_file_metadata(path)? {
             Ok(cached.mtime == mtime)
         } else {
@@ -93,7 +90,7 @@ impl FileCache {
     pub fn get_file_stats(&self, path: &Path) -> Result<Option<crate::queue::FileStats>> {
         let read_txn = self.db.begin_read()?;
         let table = read_txn.open_table(FILE_STATS_TABLE)?;
-        
+
         let path_str = path.to_string_lossy();
         let path_bytes = path_str.as_bytes();
         if let Some(data) = table.get(path_bytes)? {
@@ -118,7 +115,10 @@ impl FileCache {
         Ok(())
     }
 
-    pub fn batch_set_file_stats(&self, updates: &[(PathBuf, crate::queue::FileStats)]) -> Result<()> {
+    pub fn batch_set_file_stats(
+        &self,
+        updates: &[(PathBuf, crate::queue::FileStats)],
+    ) -> Result<()> {
         let write_txn = self.db.begin_write()?;
         {
             let mut table = write_txn.open_table(FILE_STATS_TABLE)?;
@@ -133,18 +133,20 @@ impl FileCache {
         Ok(())
     }
 
-    pub fn get_all_file_stats(&self) -> Result<std::collections::HashMap<PathBuf, crate::queue::FileStats>> {
+    pub fn get_all_file_stats(
+        &self,
+    ) -> Result<std::collections::HashMap<PathBuf, crate::queue::FileStats>> {
         let read_txn = self.db.begin_read()?;
         let table = read_txn.open_table(FILE_STATS_TABLE)?;
         let mut stats = std::collections::HashMap::new();
-        
+
         for item in table.iter()? {
             let (key, value) = item?;
             let path = PathBuf::from(String::from_utf8_lossy(key.value()).to_string());
             let file_stats: crate::queue::FileStats = bincode::deserialize(value.value())?;
             stats.insert(path, file_stats);
         }
-        
+
         Ok(stats)
     }
 
@@ -152,7 +154,7 @@ impl FileCache {
     pub fn get_playlist(&self, name: &str) -> Result<Option<crate::queue::Playlist>> {
         let read_txn = self.db.begin_read()?;
         let table = read_txn.open_table(PLAYLISTS_TABLE)?;
-        
+
         if let Some(data) = table.get(name)? {
             let playlist: crate::queue::Playlist = bincode::deserialize(data.value())?;
             Ok(Some(playlist))
@@ -172,18 +174,20 @@ impl FileCache {
         Ok(())
     }
 
-    pub fn get_all_playlists(&self) -> Result<std::collections::HashMap<String, crate::queue::Playlist>> {
+    pub fn get_all_playlists(
+        &self,
+    ) -> Result<std::collections::HashMap<String, crate::queue::Playlist>> {
         let read_txn = self.db.begin_read()?;
         let table = read_txn.open_table(PLAYLISTS_TABLE)?;
         let mut playlists = std::collections::HashMap::new();
-        
+
         for item in table.iter()? {
             let (key, value) = item?;
             let name = key.value().to_string();
             let playlist: crate::queue::Playlist = bincode::deserialize(value.value())?;
             playlists.insert(name, playlist);
         }
-        
+
         Ok(playlists)
     }
 
@@ -202,7 +206,7 @@ impl FileCache {
     pub fn is_blacklisted(&self, path: &Path) -> Result<bool> {
         let read_txn = self.db.begin_read()?;
         let table = read_txn.open_table(BLACKLIST_TABLE)?;
-        
+
         let path_str = path.to_string_lossy();
         let path_bytes = path_str.as_bytes();
         Ok(table.get(path_bytes)?.is_some())
@@ -228,13 +232,13 @@ impl FileCache {
         let read_txn = self.db.begin_read()?;
         let table = read_txn.open_table(BLACKLIST_TABLE)?;
         let mut blacklist = std::collections::HashSet::new();
-        
+
         for item in table.iter()? {
             let (key, _) = item?;
             let path = PathBuf::from(String::from_utf8_lossy(key.value()).to_string());
             blacklist.insert(path);
         }
-        
+
         Ok(blacklist)
     }
 
@@ -246,10 +250,9 @@ impl FileCache {
         {
             let mut table = write_txn.open_table(FILE_CACHE_TABLE)?;
             // Collect keys within write transaction to ensure atomicity
-            let keys: Vec<Vec<u8>> = table.iter()?
-                .filter_map(|item| {
-                    item.ok().map(|(key, _)| key.value().to_vec())
-                })
+            let keys: Vec<Vec<u8>> = table
+                .iter()?
+                .filter_map(|item| item.ok().map(|(key, _)| key.value().to_vec()))
                 .collect();
             for key in keys {
                 table.remove(key.as_slice())?;
@@ -258,7 +261,7 @@ impl FileCache {
         write_txn.commit()?;
         Ok(())
     }
-    
+
     /// Invalidate cache entry for a specific file
     pub fn invalidate_file(&self, path: &Path) -> Result<()> {
         let write_txn = self.db.begin_write()?;
@@ -284,11 +287,11 @@ pub struct DirectoryWatcher {
 impl DirectoryWatcher {
     pub fn new(cache: Arc<FileCache>) -> Result<Self> {
         let (event_tx, event_rx) = mpsc::channel(100);
-        
+
         let watcher = notify::recommended_watcher(move |res: notify::Result<Event>| {
             let _ = event_tx.blocking_send(res);
         })?;
-        
+
         Ok(Self {
             watcher,
             event_rx,
@@ -296,7 +299,7 @@ impl DirectoryWatcher {
             watched_dirs: Vec::new(),
         })
     }
-    
+
     /// Watch a directory for changes
     pub fn watch(&mut self, path: &Path) -> Result<()> {
         if path.exists() && path.is_dir() {
@@ -306,7 +309,7 @@ impl DirectoryWatcher {
         }
         Ok(())
     }
-    
+
     /// Process file system events and invalidate cache entries
     pub async fn process_events(&mut self) {
         while let Ok(Ok(event)) = self.event_rx.try_recv() {
@@ -316,9 +319,16 @@ impl DirectoryWatcher {
                         if path.is_file() {
                             // Invalidate cache entry for this file
                             if let Err(e) = self.cache.invalidate_file(&path) {
-                                tracing::warn!("[CACHE] Failed to invalidate cache for {}: {}", path.display(), e);
+                                tracing::warn!(
+                                    "[CACHE] Failed to invalidate cache for {}: {}",
+                                    path.display(),
+                                    e
+                                );
                             } else {
-                                tracing::debug!("[CACHE] Invalidated cache for: {}", path.display());
+                                tracing::debug!(
+                                    "[CACHE] Invalidated cache for: {}",
+                                    path.display()
+                                );
                             }
                         } else if path.is_dir() {
                             // Directory changed - mark all files in this directory as dirty

--- a/kaleidux-daemon/src/main.rs
+++ b/kaleidux-daemon/src/main.rs
@@ -1,16 +1,16 @@
-use tracing_subscriber::{prelude::*, EnvFilter, Registry};
-use tracing_subscriber::fmt as subscriber_fmt;
+use kaleidux_common::{Request, Response, Transition};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixListener;
+use tokio::sync::Semaphore;
+use tracing::{debug, error, info, warn};
 use tracing_subscriber::filter::LevelFilter;
-use tracing::{info, warn, debug, error};
+use tracing_subscriber::fmt as subscriber_fmt;
+use tracing_subscriber::{prelude::*, EnvFilter, Registry};
 use wayland_client::{globals::registry_queue_init, Connection};
 use x11rb::connection::Connection as X11Connection;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::collections::HashMap;
-use tokio::net::UnixListener;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::sync::Semaphore;
-use kaleidux_common::{Request, Response, Transition};
 
 // Use jemalloc for better memory fragmentation handling in long-running processes
 #[global_allocator]
@@ -18,25 +18,24 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 // Global semaphore to limit concurrent image decode tasks (prevents memory spikes)
 // Limit to 2 concurrent decodes since each can be 35-40MB
-static IMAGE_DECODE_SEMAPHORE: once_cell::sync::Lazy<Arc<Semaphore>> = once_cell::sync::Lazy::new(|| {
-    Arc::new(Semaphore::new(2))
-});
+static IMAGE_DECODE_SEMAPHORE: once_cell::sync::Lazy<Arc<Semaphore>> =
+    once_cell::sync::Lazy::new(|| Arc::new(Semaphore::new(2)));
 
-mod video;
-mod renderer;
-mod wayland;
-mod x11;
-mod orchestration;
-mod queue;
-mod monitor_manager;
-mod shaders;
-mod scripting;
-mod monitor;
 mod cache;
 mod metrics;
+mod monitor;
+mod monitor_manager;
+mod orchestration;
+mod queue;
+mod renderer;
+mod scripting;
+mod shaders;
+mod video;
+mod wayland;
+mod x11;
 
-use std::time::Instant;
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 #[derive(Debug, Clone)]
 struct LoadedImage {
@@ -66,6 +65,7 @@ impl tracing_subscriber::fmt::time::FormatTime for CustomTimer {
 use clap::Parser;
 
 /// Helper function to switch wallpaper content for an output.
+#[allow(clippy::too_many_arguments)]
 fn switch_wallpaper_content(
     name: &str,
     path: &Path,
@@ -82,30 +82,42 @@ fn switch_wallpaper_content(
     log_prefix: &str,
 ) {
     info!("{}: {} -> {:?}", log_prefix, name, path.display());
-    debug!("[SWITCH] {}: content_type={:?}, renderer exists={}", name, content_type, renderers.contains_key(name));
+    debug!(
+        "[SWITCH] {}: content_type={:?}, renderer exists={}",
+        name,
+        content_type,
+        renderers.contains_key(name)
+    );
 
     let was_playing_video = video_players.contains_key(name);
     if was_playing_video {
         if let Some(mut vp) = video_players.remove(name) {
-            debug!("[TRANSITION] {}: Offloading video player stop to background", name);
+            debug!(
+                "[TRANSITION] {}: Offloading video player stop to background",
+                name
+            );
             tokio::spawn(async move {
                 let _ = vp.stop();
             });
         }
     }
-    
+
     // CRITICAL: Ensure renderer exists before switching content
     // This prevents race conditions where content is switched before renderer is ready
     if let Some(r) = renderers.get_mut(name) {
         r.active_batch_id = batch_id;
-        r.batch_start_time = batch_trigger_time; 
+        r.batch_start_time = batch_trigger_time;
         r.set_content_type(content_type);
 
         // Resolve Random transition if configured for this output
         if let Some(orchestrator) = monitor_manager.outputs.get(name) {
             if matches!(orchestrator.config.transition, Transition::Random) {
                 let picked = Transition::pick_random();
-                debug!("[TRANSITION] {}: Resolved Random transition to: {}", name, picked.name());
+                debug!(
+                    "[TRANSITION] {}: Resolved Random transition to: {}",
+                    name,
+                    picked.name()
+                );
                 r.active_transition = picked;
             }
         }
@@ -117,21 +129,28 @@ fn switch_wallpaper_content(
             let path_clone = path.to_path_buf();
             let tx = image_tx.clone();
             let semaphore = IMAGE_DECODE_SEMAPHORE.clone();
-            
-            debug!("[ASSET] {}: Offloading image decode: {}", name, path.display());
+
+            debug!(
+                "[ASSET] {}: Offloading image decode: {}",
+                name,
+                path.display()
+            );
             tokio::spawn(async move {
                 // Acquire permit before decoding to limit concurrent tasks
                 let _permit = match semaphore.acquire().await {
                     Ok(p) => p,
                     Err(_) => {
-                        debug!("[ASSET] {}: Semaphore closed, skipping image decode", name_clone);
+                        debug!(
+                            "[ASSET] {}: Semaphore closed, skipping image decode",
+                            name_clone
+                        );
                         return;
                     }
                 };
-                
+
                 // Decode image in blocking task
-                let decode_result = tokio::task::spawn_blocking(move || {
-                    match image::open(&path_clone) {
+                let decode_result =
+                    tokio::task::spawn_blocking(move || match image::open(&path_clone) {
                         Ok(img) => {
                             let rgba = img.to_rgba8();
                             let (width, height) = rgba.dimensions();
@@ -142,9 +161,9 @@ fn switch_wallpaper_content(
                             error!("Failed to decode image {}: {}", path_clone.display(), e);
                             Err((name_clone, path_clone))
                         }
-                    }
-                }).await;
-                
+                    })
+                    .await;
+
                 // Send decoded image (or error) to channel
                 match decode_result {
                     Ok(Ok((name, image_data, width, height, path))) => {
@@ -156,7 +175,10 @@ fn switch_wallpaper_content(
                             height,
                             _path: path,
                         }) {
-                            debug!("[ASSET] {}: Failed to send decoded image (channel closed): {}", name, e);
+                            debug!(
+                                "[ASSET] {}: Failed to send decoded image (channel closed): {}",
+                                name, e
+                            );
                         }
                     }
                     Ok(Err((name, path))) => {
@@ -177,11 +199,14 @@ fn switch_wallpaper_content(
             });
         }
     }
-    
+
     if content_type == crate::queue::ContentType::Video {
         let session_id = *next_session_id;
         *next_session_id += 1;
-        debug!("[TRANSITION] {}: Starting new video player (session_id={})", name, session_id);
+        debug!(
+            "[TRANSITION] {}: Starting new video player (session_id={})",
+            name, session_id
+        );
         create_and_start_video_player(
             path,
             name,
@@ -206,42 +231,44 @@ fn create_and_start_video_player(
     if let Some(r) = renderers.get_mut(name) {
         r.active_video_session_id = session_id;
     }
-    
+
     let path_str = path.to_string_lossy().into_owned();
     let name_arc = Arc::new(name.to_string());
     let name_str = name.to_string();
     let frame_tx_clone = frame_tx.clone();
     let player_tx_clone = player_tx.clone();
-    
-    let vol = monitor_manager.outputs.get(name)
+
+    let vol = monitor_manager
+        .outputs
+        .get(name)
         .map(|o| o.config.volume as f64 / 100.0)
         .unwrap_or(1.0);
 
     tokio::task::spawn_blocking(move || {
-        match video::VideoPlayer::new(
-            &path_str,
-            name_arc,
-            session_id,
-            frame_tx_clone,
-        ) {
+        match video::VideoPlayer::new(&path_str, name_arc, session_id, frame_tx_clone) {
             Ok(mut vp) => {
                 vp.set_volume(vol);
                 // Pre-buffer video to reduce first frame latency
                 if let Err(e) = vp.prebuffer() {
-                    debug!("[VIDEO] {}: Pre-buffering failed (non-fatal): {}", name_str, e);
+                    debug!(
+                        "[VIDEO] {}: Pre-buffering failed (non-fatal): {}",
+                        name_str, e
+                    );
                 }
                 if vp.start().is_ok() {
-                    if let Err(e) = player_tx_clone.send(VideoPlayerResult::Success(name_str, session_id, vp)) {
-                         error!("Failed to send video player back: {}", e);
+                    if let Err(e) =
+                        player_tx_clone.send(VideoPlayerResult::Success(name_str, session_id, vp))
+                    {
+                        error!("Failed to send video player back: {}", e);
                     }
                 } else {
-                     error!("Failed to start video player");
-                     let _ = player_tx_clone.send(VideoPlayerResult::Failure(name_str, session_id));
+                    error!("Failed to start video player");
+                    let _ = player_tx_clone.send(VideoPlayerResult::Failure(name_str, session_id));
                 }
             }
             Err(e) => {
-                    error!("Failed to create video player: {}", e);
-                    // Note: metrics not available in this closure context
+                error!("Failed to create video player: {}", e);
+                // Note: metrics not available in this closure context
                 let _ = player_tx_clone.send(VideoPlayerResult::Failure(name_str, session_id));
             }
         }
@@ -270,16 +297,17 @@ async fn main() -> anyhow::Result<()> {
     let _guards = {
         let filter = match log_level {
             Some(1) => LevelFilter::WARN,
-            Some(2) => LevelFilter::INFO, 
+            Some(2) => LevelFilter::INFO,
             Some(3) => LevelFilter::DEBUG,
             Some(4) => LevelFilter::TRACE,
-            None | _ => LevelFilter::INFO, 
+            None => LevelFilter::INFO,
+            _ => LevelFilter::INFO,
         };
 
         let env_filter = EnvFilter::builder()
             .with_default_directive(filter.into())
             .from_env_lossy()
-            .add_directive("wgpu_core=warn".parse().unwrap()) 
+            .add_directive("wgpu_core=warn".parse().unwrap())
             .add_directive("wgpu_hal=warn".parse().unwrap())
             .add_directive("naga=warn".parse().unwrap())
             .add_directive("calloop=warn".parse().unwrap())
@@ -288,21 +316,23 @@ async fn main() -> anyhow::Result<()> {
         if let Some(level) = log_level {
             let config_dir = dirs::config_dir()
                 .ok_or_else(|| anyhow::anyhow!("Could not find config directory"))?
-                .join("kaleidux").join("logs");
+                .join("kaleidux")
+                .join("logs");
             std::fs::create_dir_all(&config_dir)?;
-            
+
             let timestamp = Local::now().format("%Y-%m-%d_%H-%M-%S");
             let log_path = config_dir.join(format!("kaleidux-daemon-{}.log", timestamp));
             let file = std::fs::File::create(&log_path)?;
             println!("Logging to file: {}", log_path.display());
             let (non_blocking_file, file_guard) = tracing_appender::non_blocking(file);
-            let (non_blocking_stdout, stdout_guard) = tracing_appender::non_blocking(std::io::stdout());
+            let (non_blocking_stdout, stdout_guard) =
+                tracing_appender::non_blocking(std::io::stdout());
 
             let file_layer = subscriber_fmt::layer()
                 .with_writer(non_blocking_file)
                 .with_ansi(false)
                 .with_timer(CustomTimer);
-            
+
             let stdout_layer = subscriber_fmt::layer()
                 .with_writer(non_blocking_stdout)
                 .with_timer(CustomTimer);
@@ -312,8 +342,12 @@ async fn main() -> anyhow::Result<()> {
                 .with(file_layer)
                 .with(stdout_layer)
                 .init();
-            
-            info!("Kaleidux Daemon starting... (Level {}, File: {})", level, config_dir.display());
+
+            info!(
+                "Kaleidux Daemon starting... (Level {}, File: {})",
+                level,
+                config_dir.display()
+            );
             (Some(file_guard), Some(stdout_guard))
         } else {
             let stdout_layer = subscriber_fmt::layer()
@@ -353,12 +387,12 @@ async fn main() -> anyhow::Result<()> {
     gstreamer::init()?;
     let gstreamer_duration = gstreamer_start.elapsed();
     info!("GStreamer initialized.");
-    
+
     // 4. Resource Monitor will be started in backend loops with metrics
-    
+
     // Detect Backend
     let use_x11 = std::env::var("WAYLAND_DISPLAY").is_err() && std::env::var("DISPLAY").is_ok();
-    
+
     if use_x11 {
         info!("Starting X11 Backend...");
         run_x11_loop(config, log_level, gstreamer_duration).await
@@ -368,32 +402,41 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
-async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, gstreamer_duration: std::time::Duration) -> anyhow::Result<()> {
+async fn run_wayland_loop(
+    config: orchestration::Config,
+    log_level: Option<u8>,
+    gstreamer_duration: std::time::Duration,
+) -> anyhow::Result<()> {
     let script_path = config.global.script_path.clone();
     let script_tick_interval = config.global.script_tick_interval;
     let metrics = Arc::new(metrics::PerformanceMetrics::new());
     metrics.record_startup_start();
     metrics.record_gstreamer_init(gstreamer_duration);
-    
+
     // Start resource monitor with metrics
     let monitor = monitor::SystemMonitor::new_with_metrics(Some(metrics.clone()));
     tokio::spawn(async move {
         monitor.run().await;
     });
-    
-    let mut monitor_manager = monitor_manager::MonitorManager::new_with_metrics(config.clone(), Some(metrics.clone()))?;
+
+    let mut monitor_manager =
+        monitor_manager::MonitorManager::new_with_metrics(config.clone(), Some(metrics.clone()))?;
     let mut last_metrics_log = Instant::now();
-    
+
     // Initialize directory watcher for cache invalidation
     let cache = monitor_manager.get_cache();
     // Directory watcher for cache invalidation (used in main loop)
     let mut dir_watcher = match cache::DirectoryWatcher::new(cache.clone()) {
         Ok(mut watcher) => {
             // Watch all content directories from config
-            for (_, output_config) in &config.outputs {
+            for output_config in config.outputs.values() {
                 if let Some(path) = &output_config.path {
                     if let Err(e) = watcher.watch(path) {
-                        tracing::warn!("[CACHE] Failed to watch directory {}: {}", path.display(), e);
+                        tracing::warn!(
+                            "[CACHE] Failed to watch directory {}: {}",
+                            path.display(),
+                            e
+                        );
                     }
                 }
             }
@@ -404,7 +447,7 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
             None
         }
     };
-    
+
     // Log metrics immediately for DEBUG (3) and TRACE (4) levels
     if log_level.map(|l| l >= 3).unwrap_or(false) {
         metrics.log_summary();
@@ -425,15 +468,16 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
     // Reasonable buffer to prevent stuttering while maintaining backpressure
     // Each frame can be 30-40MB, so 30 frames = ~900-1200MB max in channel
     // This is acceptable for smooth playback across multiple monitors
-    let (frame_tx, mut frame_rx) = tokio::sync::mpsc::channel::<(Arc<String>, video::VideoEvent)>(30);
+    let (frame_tx, mut frame_rx) =
+        tokio::sync::mpsc::channel::<(Arc<String>, video::VideoEvent)>(30);
     let mut renderers = HashMap::new();
     let outputs: Vec<_> = backend.output_state.outputs().collect();
-    
+
     let display_ptr = {
         let backend_ref = conn.backend();
         backend_ref.display_ptr() as *mut std::ffi::c_void
     };
-    
+
     let mut surface_infos = Vec::new();
     for output in outputs {
         let info = match backend.output_state.info(&output) {
@@ -442,7 +486,7 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
         };
         let name = info.name.as_deref().unwrap_or("unknown").to_string();
         let description = info.description.as_deref().unwrap_or("unknown").to_string();
-        
+
         info!("Creating surface for output: {} ({})", name, description);
         monitor_manager.add_output(&name, &description).await;
         let output_config = match monitor_manager.get_output_config(&name) {
@@ -450,8 +494,13 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
             None => continue,
         };
 
-        let layer_surface = backend.create_wallpaper_surface(&output, &qh, name.clone(), output_config.layer.clone().into())?;
-        
+        let layer_surface = backend.create_wallpaper_surface(
+            &output,
+            &qh,
+            name.clone(),
+            output_config.layer.clone().into(),
+        )?;
+
         let raw_handle_surface = wayland::RawHandleSurface {
             layer_surface,
             display_ptr,
@@ -474,50 +523,59 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
 
     if let Some(ctx) = wgpu_ctx.clone() {
         let first_name = surface_infos.first().map(|(n, _)| n.clone());
-        
+
         for (name, surface_arc) in surface_infos {
             let ctx_clone = ctx.clone();
             let is_first = Some(&name) == first_name.as_ref();
-            let init_surf = if is_first { initial_surface.take() } else { None };
-            
+            let init_surf = if is_first {
+                initial_surface.take()
+            } else {
+                None
+            };
+
             let metrics_clone = metrics.clone();
-            
+
             info!("[STARTUP] Initializing renderer for {}", name);
-            
+
             // Offload WGPU surface creation to blocking thread to avoid checking generic runtime
             let name_for_bg = name.clone();
             let spawn_handler = tokio::task::spawn_blocking(move || {
-                renderer::Renderer::new(name_for_bg, ctx_clone, surface_arc, init_surf, Some(metrics_clone))
+                renderer::Renderer::new(
+                    name_for_bg,
+                    ctx_clone,
+                    surface_arc,
+                    init_surf,
+                    Some(metrics_clone),
+                )
             });
 
             // Set a timeout strictly for the initialization
             match tokio::time::timeout(std::time::Duration::from_secs(5), spawn_handler).await {
-                Ok(join_res) => {
-                    match join_res {
-                        Ok(render_res) => {
-                            match render_res {
-                                Ok(mut r) => {
-                                    if let Some(output_config) = monitor_manager.get_output_config(&name) {
-                                        r.apply_config(output_config);
-                                    }
-                                    renderers.insert(name.clone(), r);
-                                    info!("[STARTUP] Renderer initialized successfully for {}", name);
-                                }
-                                Err(e) => {
-                                    error!("Failed to create renderer for output {}: {}", name, e);
-                                    metrics.record_error("renderer_creation");
-                                }
+                Ok(join_res) => match join_res {
+                    Ok(render_res) => match render_res {
+                        Ok(mut r) => {
+                            if let Some(output_config) = monitor_manager.get_output_config(&name) {
+                                r.apply_config(output_config);
                             }
+                            renderers.insert(name.clone(), r);
+                            info!("[STARTUP] Renderer initialized successfully for {}", name);
                         }
                         Err(e) => {
-                            error!("Thread join error for output {}: {}", name, e);
-                            metrics.record_error("renderer_thread_error");
+                            error!("Failed to create renderer for output {}: {}", name, e);
+                            metrics.record_error("renderer_creation");
                         }
+                    },
+                    Err(e) => {
+                        error!("Thread join error for output {}: {}", name, e);
+                        metrics.record_error("renderer_thread_error");
                     }
-                }
+                },
                 Err(_) => {
                     // Timeout occurred
-                    error!("TIMEOUT: Renderer initialization for {} took longer than 5s. Skipping.", name);
+                    error!(
+                        "TIMEOUT: Renderer initialization for {} took longer than 5s. Skipping.",
+                        name
+                    );
                     metrics.record_error("renderer_creation_timeout");
                 }
             }
@@ -529,15 +587,19 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
         if log_level.map(|l| l >= 3).unwrap_or(false) {
             metrics.log_startup_summary();
         }
-        info!("[STARTUP] All renderers created, count: {}", renderers.len());
+        info!(
+            "[STARTUP] All renderers created, count: {}",
+            renderers.len()
+        );
     } else {
         warn!("[STARTUP] No WGPU context available, cannot create renderers!");
     }
-    
+
     info!("[STARTUP] Creating video players HashMap");
     let mut video_players: HashMap<String, video::VideoPlayer> = HashMap::new();
 
-    let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::unbounded_channel::<(Request, tokio::sync::oneshot::Sender<Response>)>();
+    let (cmd_tx, mut cmd_rx) =
+        tokio::sync::mpsc::unbounded_channel::<(Request, tokio::sync::oneshot::Sender<Response>)>();
     // Image channel: unbounded to support many monitors simultaneously
     // Each image can be 35-40MB, but with proper processing this shouldn't accumulate
     // Unbounded allows all monitors to load images without blocking
@@ -553,12 +615,12 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
             let uid = std::env::var("USER").unwrap_or_else(|_| "kaleidux".to_string());
             std::path::PathBuf::from(format!("/tmp/kaleidux-{}.sock", uid))
         });
-    
+
     info!("[STARTUP] IPC socket path: {:?}", socket_path);
     let _ = std::fs::remove_file(&socket_path);
     let listener = UnixListener::bind(&socket_path)?;
     info!("[STARTUP] IPC socket bound successfully");
-    
+
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -579,7 +641,9 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
                     const MAX_MESSAGE_SIZE: usize = 8192;
                     let mut temp_buf = [0u8; MAX_MESSAGE_SIZE];
                     if let Ok(n) = stream.read(&mut temp_buf).await {
-                        if n == 0 || n >= MAX_MESSAGE_SIZE { return; }
+                        if n == 0 || n >= MAX_MESSAGE_SIZE {
+                            return;
+                        }
                         if let Ok(req_str) = std::str::from_utf8(&temp_buf[..n]) {
                             if let Ok(req) = serde_json::from_str::<Request>(req_str.trim()) {
                                 let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
@@ -623,14 +687,23 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
     let mut last_pool_cleanup = Instant::now();
     let mut last_stats_flush = Instant::now();
     let mut first_frame_recorded = false;
-    
+
     // Initial Load
-    info!("[STARTUP] Reached Initial Load section, renderers count: {}", renderers.len());
+    info!(
+        "[STARTUP] Reached Initial Load section, renderers count: {}",
+        renderers.len()
+    );
     info!("[STARTUP] About to call monitor_manager.tick()");
     let initial_changes = monitor_manager.tick();
-    info!("[STARTUP] Initial changes: {} outputs", initial_changes.len());
+    info!(
+        "[STARTUP] Initial changes: {} outputs",
+        initial_changes.len()
+    );
     for (name, (path, content_type)) in &initial_changes {
-        info!("[STARTUP] Change: {} -> {:?} ({:?})", name, path, content_type);
+        info!(
+            "[STARTUP] Change: {} -> {:?} ({:?})",
+            name, path, content_type
+        );
     }
     if initial_changes.is_empty() {
         warn!("[STARTUP] No initial content changes - wallpapers may not load!");
@@ -638,24 +711,36 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
     let mut next_session_id = 1u64;
     let batch_id = rand::random::<u64>();
     for (name, (path, content_type)) in initial_changes {
-         switch_wallpaper_content(
-            &name, &path, content_type, &mut next_session_id, &frame_tx,
-            &monitor_manager, &mut renderers, &mut video_players,
-            Some(batch_id), None, &image_tx, &player_tx, "STARTUP"
-         );
+        switch_wallpaper_content(
+            &name,
+            &path,
+            content_type,
+            &mut next_session_id,
+            &frame_tx,
+            &monitor_manager,
+            &mut renderers,
+            &mut video_players,
+            Some(batch_id),
+            None,
+            &image_tx,
+            &player_tx,
+            "STARTUP",
+        );
     }
-    
+
     // Main Loop (Wayland)
     loop {
         let loop_start = Instant::now();
         if shutdown_flag.load(Ordering::SeqCst) {
-            for (_, player) in &mut video_players { let _ = player.stop(); }
+            for player in video_players.values_mut() {
+                let _ = player.stop();
+            }
             break;
         }
 
         if connection_dead {
             if last_error_time.elapsed().as_secs() > 5 {
-                connection_dead = false; 
+                connection_dead = false;
                 connection_error_count = 0;
             } else {
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -665,15 +750,19 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
 
         // Wayland Event Polling
         if let Some(guard) = conn.prepare_read() {
-             use std::os::unix::io::{AsRawFd, AsFd};
-             let fd = conn.as_fd().as_raw_fd();
-             let mut poll_fd = libc::pollfd { fd, events: libc::POLLIN, revents: 0 };
-             let ret = unsafe { libc::poll(&mut poll_fd, 1, 5) };
-             if ret > 0 && (poll_fd.revents & libc::POLLIN != 0) {
-                 let _ = guard.read();
-             }
+            use std::os::unix::io::{AsFd, AsRawFd};
+            let fd = conn.as_fd().as_raw_fd();
+            let mut poll_fd = libc::pollfd {
+                fd,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            let ret = unsafe { libc::poll(&mut poll_fd, 1, 5) };
+            if ret > 0 && (poll_fd.revents & libc::POLLIN != 0) {
+                let _ = guard.read();
+            }
         }
-        
+
         if let Err(e) = event_queue.dispatch_pending(&mut backend) {
             let error_str = e.to_string();
             if error_str.contains("Broken pipe") {
@@ -684,29 +773,37 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
                 }
             }
         }
-        
+
         if !connection_dead {
-            let needs_flush = renderers.values().any(|r| r.needs_redraw || r.transition_active);
+            let needs_flush = renderers
+                .values()
+                .any(|r| r.needs_redraw || r.transition_active);
             if needs_flush {
-                 let _ = conn.flush();
+                let _ = conn.flush();
             }
         }
 
         // Logic (Common)
         {
             // Remove orphaned renderers
-            let active_output_names: std::collections::HashSet<String> = backend.output_state.outputs().filter_map(|o| {
-                backend.output_state.info(&o).and_then(|i| i.name.clone())
-            }).collect();
+            let active_output_names: std::collections::HashSet<String> = backend
+                .output_state
+                .outputs()
+                .filter_map(|o| backend.output_state.info(&o).and_then(|i| i.name.clone()))
+                .collect();
             renderers.retain(|name, _| {
                 if !active_output_names.contains(name) {
                     if let Some(mut vp) = video_players.remove(name) {
-                        tokio::spawn(async move { let _ = vp.stop(); });
+                        tokio::spawn(async move {
+                            let _ = vp.stop();
+                        });
                     }
                     false
-                } else { true }
+                } else {
+                    true
+                }
             });
-            
+
             // Handle Resizes
             let resizes: Vec<_> = backend.pending_resizes.drain(..).collect();
             for (name, w, h, _) in resizes {
@@ -715,42 +812,72 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
                     let height = if h == 0 { r.config.height } else { h };
                     let _ = r.resize_checked(width, height);
                     if r.configured {
-                        if let Some((_, layer_surface)) = backend.surfaces.iter().find(|(n, _)| n == &name) {
-                             // Force an initial render to commit the surface after resize
-                             // This ensures the compositor knows the surface is ready and will send frame callbacks
-                             let _ = r.render(renderer::BackendContext::Wayland { surface: layer_surface, qh: &qh }, loop_start);
-                             r.request_frame_callback(layer_surface, &qh);
+                        if let Some((_, layer_surface)) =
+                            backend.surfaces.iter().find(|(n, _)| n == &name)
+                        {
+                            // Force an initial render to commit the surface after resize
+                            // This ensures the compositor knows the surface is ready and will send frame callbacks
+                            let _ = r.render(
+                                renderer::BackendContext::Wayland {
+                                    surface: layer_surface,
+                                    qh: &qh,
+                                },
+                                loop_start,
+                            );
+                            r.request_frame_callback(layer_surface, &qh);
                         }
                     }
                 }
             }
         }
-        
+
         // Automated Changes
         let scheduled_changes = monitor_manager.tick();
         if !scheduled_changes.is_empty() {
             let batch_id = rand::random::<u64>();
             for (name, (path, content_type)) in scheduled_changes {
-                 switch_wallpaper_content(
-                    &name, &path, content_type, &mut next_session_id, &frame_tx,
-                    &monitor_manager, &mut renderers, &mut video_players,
-                    Some(batch_id), Some(loop_start), &image_tx, &player_tx, "SCHEDULED"
-                 );
+                switch_wallpaper_content(
+                    &name,
+                    &path,
+                    content_type,
+                    &mut next_session_id,
+                    &frame_tx,
+                    &monitor_manager,
+                    &mut renderers,
+                    &mut video_players,
+                    Some(batch_id),
+                    Some(loop_start),
+                    &image_tx,
+                    &player_tx,
+                    "SCHEDULED",
+                );
             }
         }
-        
+
         // Scripting
         if last_script_tick.elapsed().as_secs() >= script_tick_interval {
             script_manager.tick();
             last_script_tick = Instant::now();
         }
-        
+
         // Handle Commands
         while let Ok((req, resp)) = cmd_rx.try_recv() {
-             let response = handle_command(req, &mut monitor_manager, &mut renderers, &mut video_players, &frame_tx, &image_tx, &player_tx, &mut next_session_id, loop_start, &shutdown_flag).await;
-             let _ = resp.send(response);
+            let response = handle_command(
+                req,
+                &mut monitor_manager,
+                &mut renderers,
+                &mut video_players,
+                &frame_tx,
+                &image_tx,
+                &player_tx,
+                &mut next_session_id,
+                loop_start,
+                &shutdown_flag,
+            )
+            .await;
+            let _ = resp.send(response);
         }
-        
+
         // Handle Frames
         // CRITICAL: Process ALL frames in channel, not just latest per source
         // This prevents frame accumulation and memory leaks
@@ -778,7 +905,10 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
         if frames_received > 0 {
             metrics.record_frame_channel_size(frames_received);
             if frames_discarded > 0 {
-                debug!("[VIDEO] Discarded {} older frames (keeping latest per source)", frames_discarded);
+                debug!(
+                    "[VIDEO] Discarded {} older frames (keeping latest per source)",
+                    frames_discarded
+                );
             }
         }
         // Process all frames (one per source, the latest)
@@ -791,14 +921,24 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
                 metrics.record_video_cpu_time(video_duration);
                 // CRITICAL: Explicitly drop frame after processing to release gst::Buffer
                 drop(frame);
-                
+
                 if r.valid_content_type == crate::queue::ContentType::Video {
-                    if let Some((_, layer_surface)) = backend.surfaces.iter().find(|(n, _)| n == source_id.as_str()) {
+                    if let Some((_, layer_surface)) = backend
+                        .surfaces
+                        .iter()
+                        .find(|(n, _)| n == source_id.as_str())
+                    {
                         // Deadlock fix: if this is the first frame of a transition (progress == 0),
                         // we MUST render and commit it to trigger the Wayland frame callback loop,
                         // even if a callback is technically "pending" from the switch event.
                         if !r.frame_callback_pending || r.transition_progress == 0.0 {
-                            let _ = r.render(renderer::BackendContext::Wayland{surface: layer_surface, qh: &qh}, loop_start);
+                            let _ = r.render(
+                                renderer::BackendContext::Wayland {
+                                    surface: layer_surface,
+                                    qh: &qh,
+                                },
+                                loop_start,
+                            );
                             if !first_frame_recorded {
                                 metrics.record_first_frame();
                                 first_frame_recorded = true;
@@ -812,47 +952,70 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
                 drop(frame);
             }
         }
-        
+
         // Handle Images
         let mut images_received = 0;
         while let Ok(msg) = image_rx.try_recv() {
             images_received += 1;
-            debug!("[IMAGE] Received image for {}: data={}, size={}x{}", msg.name, msg.data.is_some(), msg.width, msg.height);
-             if let Some(r) = renderers.get_mut(&msg.name) {
-                     if let Some(data) = msg.data {
-                     debug!("[IMAGE] Uploading image data for {}: {} bytes", msg.name, data.len());
-                     let _ = r.upload_image_data(data, msg.width, msg.height);
-                     debug!("[IMAGE] Rendering after upload for {}", msg.name);
-                     if r.configured {
-                          if let Some((_, layer_surface)) = backend.surfaces.iter().find(|(n, _)| n == &msg.name) {
-                              let _ = r.render(renderer::BackendContext::Wayland{surface: layer_surface, qh: &qh}, loop_start);
-                              if !first_frame_recorded {
-                                  metrics.record_first_frame();
-                                  first_frame_recorded = true;
-                              }
-                          }
-                     }
-                 } else {
-                     r.abort_transition();
-                 }
-             } else {
-                 // CRITICAL: Renderer doesn't exist - drop image data immediately to prevent memory leak
-                 warn!("[IMAGE] {}: Renderer not found, dropping image data to prevent memory leak", msg.name);
-                 // msg.data is dropped here, freeing the Vec<u8>
-             }
+            debug!(
+                "[IMAGE] Received image for {}: data={}, size={}x{}",
+                msg.name,
+                msg.data.is_some(),
+                msg.width,
+                msg.height
+            );
+            if let Some(r) = renderers.get_mut(&msg.name) {
+                if let Some(data) = msg.data {
+                    debug!(
+                        "[IMAGE] Uploading image data for {}: {} bytes",
+                        msg.name,
+                        data.len()
+                    );
+                    let _ = r.upload_image_data(data, msg.width, msg.height);
+                    debug!("[IMAGE] Rendering after upload for {}", msg.name);
+                    if r.configured {
+                        if let Some((_, layer_surface)) =
+                            backend.surfaces.iter().find(|(n, _)| n == &msg.name)
+                        {
+                            let _ = r.render(
+                                renderer::BackendContext::Wayland {
+                                    surface: layer_surface,
+                                    qh: &qh,
+                                },
+                                loop_start,
+                            );
+                            if !first_frame_recorded {
+                                metrics.record_first_frame();
+                                first_frame_recorded = true;
+                            }
+                        }
+                    }
+                } else {
+                    r.abort_transition();
+                }
+            } else {
+                // CRITICAL: Renderer doesn't exist - drop image data immediately to prevent memory leak
+                warn!(
+                    "[IMAGE] {}: Renderer not found, dropping image data to prevent memory leak",
+                    msg.name
+                );
+                // msg.data is dropped here, freeing the Vec<u8>
+            }
         }
         // Track image channel usage for memory leak detection
         if images_received > 0 {
             metrics.record_image_channel_size(images_received);
         }
-        
+
         // Async Video Players
         while let Ok(res) = player_rx.try_recv() {
             match res {
                 VideoPlayerResult::Success(name, session_id, mut player) => {
                     if renderers.get(&name).map(|r| r.active_video_session_id) == Some(session_id) {
                         if let Some(mut old) = video_players.insert(name, player) {
-                            tokio::spawn(async move { let _ = old.stop(); });
+                            tokio::spawn(async move {
+                                let _ = old.stop();
+                            });
                         }
                     } else {
                         // Stale player - stop in background to avoid blocking main loop
@@ -870,29 +1033,40 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
                 }
             }
         }
-        
+
         // Rendering
         let frame_ready_names: Vec<String> = backend.frame_callback_ready.drain().collect();
         for name in frame_ready_names {
             if let Some(r) = renderers.get_mut(&name) {
                 r.frame_callback_pending = false;
                 r.last_frame_request = None;
-                if let Some((_, layer_surface)) = backend.surfaces.iter().find(|(n, _)| n == &name) {
-                     let _ = r.render(renderer::BackendContext::Wayland { surface: layer_surface, qh: &qh }, loop_start);
-                     if !first_frame_recorded {
-                         metrics.record_first_frame();
-                         first_frame_recorded = true;
-                     }
+                if let Some((_, layer_surface)) = backend.surfaces.iter().find(|(n, _)| n == &name)
+                {
+                    let _ = r.render(
+                        renderer::BackendContext::Wayland {
+                            surface: layer_surface,
+                            qh: &qh,
+                        },
+                        loop_start,
+                    );
+                    if !first_frame_recorded {
+                        metrics.record_first_frame();
+                        first_frame_recorded = true;
+                    }
                 }
             }
         }
-        
+
         // Request missing frames and check for transition completion
         for (name, r) in renderers.iter_mut() {
-            if (r.needs_redraw || r.transition_active || r.valid_content_type == crate::queue::ContentType::Video) && !r.frame_callback_pending {
-                 if let Some((_, layer_surface)) = backend.surfaces.iter().find(|(n, _)| n == name) {
-                      r.request_frame_callback(layer_surface, &qh);
-                 }
+            if (r.needs_redraw
+                || r.transition_active
+                || r.valid_content_type == crate::queue::ContentType::Video)
+                && !r.frame_callback_pending
+            {
+                if let Some((_, layer_surface)) = backend.surfaces.iter().find(|(n, _)| n == name) {
+                    r.request_frame_callback(layer_surface, &qh);
+                }
             }
             // Check if transition just completed (for cases where render wasn't called this loop)
             if r.transition_just_completed {
@@ -900,11 +1074,11 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
                 monitor_manager.mark_transition_completed(name);
             }
         }
-        
+
         // Record frame time
         let frame_time = loop_start.elapsed();
         metrics.record_frame_time(frame_time);
-        
+
         // Cleanup texture pool periodically (every 3 seconds for more aggressive cleanup)
         if last_pool_cleanup.elapsed().as_secs() >= 3 {
             if let Some(ctx) = &wgpu_ctx {
@@ -913,25 +1087,25 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
             }
             last_pool_cleanup = Instant::now();
         }
-        
+
         // Flush stats every 5 seconds (batched writes)
         if last_stats_flush.elapsed().as_secs() >= 5 {
             let _ = monitor_manager.flush_all_stats();
             last_stats_flush = Instant::now();
         }
-        
+
         // Process directory watcher events (cache invalidation)
         if let Some(ref mut watcher) = dir_watcher {
             watcher.process_events().await;
         }
-        
+
         // Log metrics summary every 30 seconds (or 10 seconds for testing)
         if last_metrics_log.elapsed().as_secs() >= 10 {
             // Record resource counts for leak detection
             if let Some(ctx) = &wgpu_ctx {
                 let texture_count = ctx.texture_pool.lock().values().map(|v| v.len()).sum();
-                let pipeline_count = ctx.transition_pipelines.lock().len() 
-                    + ctx.blit_pipelines.lock().len() 
+                let pipeline_count = ctx.transition_pipelines.lock().len()
+                    + ctx.blit_pipelines.lock().len()
                     + ctx.mipmap_pipelines.lock().len();
                 metrics.record_texture_count(texture_count);
                 metrics.record_pipeline_count(pipeline_count);
@@ -939,46 +1113,57 @@ async fn run_wayland_loop(config: orchestration::Config, log_level: Option<u8>, 
             metrics.log_summary();
             last_metrics_log = Instant::now();
         }
-        
+
         // Timing
         let elapsed = loop_start.elapsed();
         if elapsed < target_frame_time {
             tokio::time::sleep(target_frame_time - elapsed).await;
         }
-        if let Some(ctx) = &wgpu_ctx { ctx.device.poll(wgpu::Maintain::Poll); }
+        if let Some(ctx) = &wgpu_ctx {
+            ctx.device.poll(wgpu::Maintain::Poll);
+        }
     }
-    
+
     Ok(())
 }
 
-async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstreamer_duration: std::time::Duration) -> anyhow::Result<()> {
+async fn run_x11_loop(
+    config: orchestration::Config,
+    log_level: Option<u8>,
+    gstreamer_duration: std::time::Duration,
+) -> anyhow::Result<()> {
     // Similar to run_wayland_loop but with X11 backend
     let script_path = config.global.script_path.clone();
     let script_tick_interval = config.global.script_tick_interval;
     let metrics = Arc::new(metrics::PerformanceMetrics::new());
     metrics.record_startup_start();
     metrics.record_gstreamer_init(gstreamer_duration);
-    
+
     // Start resource monitor with metrics
     let monitor = monitor::SystemMonitor::new_with_metrics(Some(metrics.clone()));
     tokio::spawn(async move {
         monitor.run().await;
     });
-    
-    let mut monitor_manager = monitor_manager::MonitorManager::new_with_metrics(config.clone(), Some(metrics.clone()))?;
+
+    let mut monitor_manager =
+        monitor_manager::MonitorManager::new_with_metrics(config.clone(), Some(metrics.clone()))?;
     let mut last_metrics_log = Instant::now();
     let mut first_frame_recorded_x11 = false;
     let mut last_stats_flush_x11 = Instant::now();
-    
+
     // Initialize directory watcher for cache invalidation
     let cache = monitor_manager.get_cache();
     let mut dir_watcher = match cache::DirectoryWatcher::new(cache.clone()) {
         Ok(mut watcher) => {
             // Watch all content directories from config
-            for (_, output_config) in &config.outputs {
+            for output_config in config.outputs.values() {
                 if let Some(path) = &output_config.path {
                     if let Err(e) = watcher.watch(path) {
-                        tracing::warn!("[CACHE] Failed to watch directory {}: {}", path.display(), e);
+                        tracing::warn!(
+                            "[CACHE] Failed to watch directory {}: {}",
+                            path.display(),
+                            e
+                        );
                     }
                 }
             }
@@ -989,7 +1174,7 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
             None
         }
     };
-    
+
     // Log metrics immediately for DEBUG (3) and TRACE (4) levels
     if log_level.map(|l| l >= 3).unwrap_or(false) {
         metrics.log_summary();
@@ -1005,10 +1190,10 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
 
     let mut surface_infos = Vec::new();
     for (name, x, y, width, height) in monitors {
-        monitor_manager.add_output(&name, "X11 Display").await; 
+        monitor_manager.add_output(&name, "X11 Display").await;
         let win = backend.create_wallpaper_window(&name, x, y, width, height)?;
         window_to_renderer.insert(win, name.clone());
-        
+
         let raw_handle = x11::RawX11Surface {
             window_id: win,
             connection: backend.conn.clone(),
@@ -1030,11 +1215,13 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
 
     if let Some(ctx) = wgpu_ctx.clone() {
         let first_name = surface_infos.first().map(|(n, _, _, _)| n.clone());
-        
+
         for (name, surface_arc, width, height) in surface_infos {
             let ctx_clone = ctx.clone();
             let is_first = Some(&name) == first_name.as_ref();
-            let init_surf = if is_first { initial_surface.take() } else {
+            let init_surf = if is_first {
+                initial_surface.take()
+            } else {
                 match ctx_clone.instance.create_surface(surface_arc.clone()) {
                     Ok(s) => Some(s),
                     Err(e) => {
@@ -1043,37 +1230,42 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
                     }
                 }
             };
-            
+
             let metrics_clone = metrics.clone();
-            
+
             info!("[STARTUP-X11] Initializing renderer for {}", name);
             let name_for_bg = name.clone();
             let spawn_handler = tokio::task::spawn_blocking(move || {
-                renderer::Renderer::new(name_for_bg, ctx_clone, surface_arc, init_surf, Some(metrics_clone))
+                renderer::Renderer::new(
+                    name_for_bg,
+                    ctx_clone,
+                    surface_arc,
+                    init_surf,
+                    Some(metrics_clone),
+                )
             });
 
             match tokio::time::timeout(std::time::Duration::from_secs(5), spawn_handler).await {
-                Ok(join_res) => {
-                    match join_res {
-                        Ok(render_res) => {
-                            match render_res {
-                                Ok(mut r) => {
-                                     let _ = r.resize_checked(width as u32, height as u32);
-                                     if let Some(cfg) = monitor_manager.get_output_config(&name) {
-                                         r.apply_config(cfg);
-                                     }
-                                     renderers.insert(name, r);
-                                }
-                                Err(e) => error!("Failed to create renderer for {}: {}", name, e),
+                Ok(join_res) => match join_res {
+                    Ok(render_res) => match render_res {
+                        Ok(mut r) => {
+                            let _ = r.resize_checked(width as u32, height as u32);
+                            if let Some(cfg) = monitor_manager.get_output_config(&name) {
+                                r.apply_config(cfg);
                             }
+                            renderers.insert(name, r);
                         }
-                        Err(e) => error!("Thread join error for output {}: {}", name, e),
-                    }
-                }
-                Err(_) => error!("TIMEOUT: Renderer initialization for {} took longer than 5s. Skipping.", name),
+                        Err(e) => error!("Failed to create renderer for {}: {}", name, e),
+                    },
+                    Err(e) => error!("Thread join error for output {}: {}", name, e),
+                },
+                Err(_) => error!(
+                    "TIMEOUT: Renderer initialization for {} took longer than 5s. Skipping.",
+                    name
+                ),
             }
         }
-        
+
         // All renderers created - full initialization complete
         metrics.record_full_init();
         if log_level.map(|l| l >= 3).unwrap_or(false) {
@@ -1086,14 +1278,16 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
     // Reasonable buffer to prevent stuttering while maintaining backpressure
     // Each frame can be 30-40MB, so 30 frames = ~900-1200MB max in channel
     // This is acceptable for smooth playback across multiple monitors
-    let (frame_tx, mut frame_rx) = tokio::sync::mpsc::channel::<(Arc<String>, video::VideoEvent)>(30);
-    let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::unbounded_channel::<(Request, tokio::sync::oneshot::Sender<Response>)>();
+    let (frame_tx, mut frame_rx) =
+        tokio::sync::mpsc::channel::<(Arc<String>, video::VideoEvent)>(30);
+    let (cmd_tx, mut cmd_rx) =
+        tokio::sync::mpsc::unbounded_channel::<(Request, tokio::sync::oneshot::Sender<Response>)>();
     // Image channel: unbounded to support many monitors simultaneously
     // Each image can be 35-40MB, but with proper processing this shouldn't accumulate
     // Unbounded allows all monitors to load images without blocking
     let (image_tx, mut image_rx) = tokio::sync::mpsc::unbounded_channel::<LoadedImage>();
     let (player_tx, mut player_rx) = tokio::sync::mpsc::unbounded_channel::<VideoPlayerResult>();
-    
+
     // IPC Listener (duplicated setup for now to avoid complexity extracting)
     let socket_path = dirs::runtime_dir()
         .map(|d| d.join("kaleidux.sock"))
@@ -1105,21 +1299,22 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
     let listener = UnixListener::bind(&socket_path)?;
     let cmd_tx_clone = cmd_tx.clone();
     tokio::spawn(async move {
-        loop { // Simplified IPC loop
+        loop {
+            // Simplified IPC loop
             if let Ok((mut stream, _)) = listener.accept().await {
-                 let cmd_tx = cmd_tx_clone.clone();
-                 tokio::spawn(async move {
-                     let mut buf = [0u8; 8192];
-                     if let Ok(n) = stream.read(&mut buf).await {
-                         if let Ok(req) = serde_json::from_slice::<Request>(&buf[..n]) {
-                             let (tx, rx) = tokio::sync::oneshot::channel();
-                             let _ = cmd_tx.send((req, tx));
-                             if let Ok(resp) = rx.await {
-                                 let _ = stream.write_all(&serde_json::to_vec(&resp).unwrap()).await;
-                             }
-                         }
-                     }
-                 });
+                let cmd_tx = cmd_tx_clone.clone();
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 8192];
+                    if let Ok(n) = stream.read(&mut buf).await {
+                        if let Ok(req) = serde_json::from_slice::<Request>(&buf[..n]) {
+                            let (tx, rx) = tokio::sync::oneshot::channel();
+                            let _ = cmd_tx.send((req, tx));
+                            if let Ok(resp) = rx.await {
+                                let _ = stream.write_all(&serde_json::to_vec(&resp).unwrap()).await;
+                            }
+                        }
+                    }
+                });
             }
         }
     });
@@ -1128,28 +1323,46 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
     // Initial Load
     info!("[STARTUP] About to call monitor_manager.tick()");
     let initial_changes = monitor_manager.tick();
-    info!("[STARTUP] Initial changes: {} outputs", initial_changes.len());
+    info!(
+        "[STARTUP] Initial changes: {} outputs",
+        initial_changes.len()
+    );
     for (name, (path, content_type)) in &initial_changes {
-        info!("[STARTUP] Change: {} -> {:?} ({:?})", name, path, content_type);
+        info!(
+            "[STARTUP] Change: {} -> {:?} ({:?})",
+            name, path, content_type
+        );
     }
     if initial_changes.is_empty() {
         warn!("[STARTUP] No initial content changes - wallpapers may not load!");
     }
     let batch_id = rand::random::<u64>();
     for (name, (path, content_type)) in initial_changes {
-         switch_wallpaper_content(
-            &name, &path, content_type, &mut next_session_id, &frame_tx,
-            &monitor_manager, &mut renderers, &mut video_players,
-            Some(batch_id), None, &image_tx, &player_tx, "STARTUP"
-         );
+        switch_wallpaper_content(
+            &name,
+            &path,
+            content_type,
+            &mut next_session_id,
+            &frame_tx,
+            &monitor_manager,
+            &mut renderers,
+            &mut video_players,
+            Some(batch_id),
+            None,
+            &image_tx,
+            &player_tx,
+            "STARTUP",
+        );
     }
-    
+
     let mut script_manager = scripting::ScriptManager::new(cmd_tx.clone());
-    if let Some(path) = &script_path { let _ = script_manager.load(path); }
+    if let Some(path) = &script_path {
+        drop(script_manager.load(path));
+    }
     let mut last_script_tick = Instant::now();
     let target_frame_time = std::time::Duration::from_micros(16667);
     let mut last_pool_cleanup_x11 = Instant::now();
-    
+
     let shutdown_flag = Arc::new(AtomicBool::new(false));
     let shutdown_clone = shutdown_flag.clone();
     tokio::spawn(async move {
@@ -1157,11 +1370,13 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
         warn!("Received shutdown signal, cleaning up...");
         shutdown_clone.store(true, Ordering::SeqCst);
     });
-    
+
     // X11 Loop
     loop {
         let loop_start = Instant::now();
-        if shutdown_flag.load(Ordering::SeqCst) { break; }
+        if shutdown_flag.load(Ordering::SeqCst) {
+            break;
+        }
 
         // Poll X11 events (non-blocking)
         while let Ok(maybe_event) = backend.conn.poll_for_event() {
@@ -1193,10 +1408,10 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
                 break;
             }
         }
-        
+
         // Logic
         if last_script_tick.elapsed().as_secs() >= script_tick_interval {
-            script_manager.tick(); 
+            script_manager.tick();
             last_script_tick = Instant::now();
         }
 
@@ -1205,20 +1420,42 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
         if !scheduled_changes.is_empty() {
             let batch_id = rand::random::<u64>();
             for (name, (path, content_type)) in scheduled_changes {
-                 switch_wallpaper_content(
-                    &name, &path, content_type, &mut next_session_id, &frame_tx,
-                    &monitor_manager, &mut renderers, &mut video_players,
-                    Some(batch_id), Some(loop_start), &image_tx, &player_tx, "SCHEDULED"
-                 );
+                switch_wallpaper_content(
+                    &name,
+                    &path,
+                    content_type,
+                    &mut next_session_id,
+                    &frame_tx,
+                    &monitor_manager,
+                    &mut renderers,
+                    &mut video_players,
+                    Some(batch_id),
+                    Some(loop_start),
+                    &image_tx,
+                    &player_tx,
+                    "SCHEDULED",
+                );
             }
         }
-        
+
         // Commands
         while let Ok((req, resp)) = cmd_rx.try_recv() {
-             let response = handle_command(req, &mut monitor_manager, &mut renderers, &mut video_players, &frame_tx, &image_tx, &player_tx, &mut next_session_id, loop_start, &shutdown_flag).await;
-             let _ = resp.send(response);
+            let response = handle_command(
+                req,
+                &mut monitor_manager,
+                &mut renderers,
+                &mut video_players,
+                &frame_tx,
+                &image_tx,
+                &player_tx,
+                &mut next_session_id,
+                loop_start,
+                &shutdown_flag,
+            )
+            .await;
+            let _ = resp.send(response);
         }
-        
+
         // Frames / Images / Video Players
         // CRITICAL: Process ALL frames in channel, not just latest per source
         let (latest_frames, frames_received, frames_discarded_x11) = {
@@ -1240,7 +1477,10 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
         if frames_received > 0 {
             metrics.record_frame_channel_size(frames_received);
             if frames_discarded_x11 > 0 {
-                debug!("[VIDEO] Discarded {} older frames (keeping latest per source)", frames_discarded_x11);
+                debug!(
+                    "[VIDEO] Discarded {} older frames (keeping latest per source)",
+                    frames_discarded_x11
+                );
             }
         }
         for (src, frame) in latest_frames {
@@ -1252,7 +1492,7 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
                 metrics.record_video_cpu_time(video_duration);
                 // CRITICAL: Explicitly drop frame after processing to release gst::Buffer
                 drop(frame);
-                
+
                 // X11: Render immediately if video
                 let _ = r.render(renderer::BackendContext::X11, loop_start);
                 if !first_frame_recorded_x11 {
@@ -1273,20 +1513,23 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
         while let Ok(msg) = image_rx.try_recv() {
             images_received_x11 += 1;
             if let Some(r) = renderers.get_mut(&msg.name) {
-                 if let Some(data) = msg.data {
-                     let _ = r.upload_image_data(data, msg.width, msg.height);
-                     let _ = r.render(renderer::BackendContext::X11, loop_start);
-                     // Check if transition just completed and mark it
-                     if r.transition_just_completed {
-                         r.transition_just_completed = false; // Clear flag
-                         monitor_manager.mark_transition_completed(&msg.name);
-                     }
-                 } else {
-                     r.abort_transition();
-                 }
+                if let Some(data) = msg.data {
+                    let _ = r.upload_image_data(data, msg.width, msg.height);
+                    let _ = r.render(renderer::BackendContext::X11, loop_start);
+                    // Check if transition just completed and mark it
+                    if r.transition_just_completed {
+                        r.transition_just_completed = false; // Clear flag
+                        monitor_manager.mark_transition_completed(&msg.name);
+                    }
+                } else {
+                    r.abort_transition();
+                }
             } else {
                 // CRITICAL: Renderer doesn't exist - drop image data immediately to prevent memory leak
-                warn!("[IMAGE] {}: Renderer not found, dropping image data to prevent memory leak", msg.name);
+                warn!(
+                    "[IMAGE] {}: Renderer not found, dropping image data to prevent memory leak",
+                    msg.name
+                );
                 // msg.data is dropped here, freeing the Vec<u8>
             }
         }
@@ -1295,30 +1538,37 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
             metrics.record_image_channel_size(images_received_x11);
         }
         while let Ok(msg) = player_rx.try_recv() {
-             match msg {
-                 VideoPlayerResult::Success(name, session_id, mut p) => {
-                     if renderers.get(&name).map(|r| r.active_video_session_id) == Some(session_id) {
-                         if let Some(mut existing) = video_players.insert(name, p) {
-                             tokio::spawn(async move { let _ = existing.stop(); });
-                         }
-                     } else {
-                          // Stale - stop in background
-                          tokio::spawn(async move { let _ = p.stop(); });
-                     }
-                 }
-                 VideoPlayerResult::Failure(name, session_id) => {
-                     if renderers.get(&name).map(|r| r.active_video_session_id) == Some(session_id) {
-                         if let Some(r) = renderers.get_mut(&name) {
-                             r.abort_transition();
-                         }
-                     }
-                 }
-             }
+            match msg {
+                VideoPlayerResult::Success(name, session_id, mut p) => {
+                    if renderers.get(&name).map(|r| r.active_video_session_id) == Some(session_id) {
+                        if let Some(mut existing) = video_players.insert(name, p) {
+                            tokio::spawn(async move {
+                                let _ = existing.stop();
+                            });
+                        }
+                    } else {
+                        // Stale - stop in background
+                        tokio::spawn(async move {
+                            let _ = p.stop();
+                        });
+                    }
+                }
+                VideoPlayerResult::Failure(name, session_id) => {
+                    if renderers.get(&name).map(|r| r.active_video_session_id) == Some(session_id) {
+                        if let Some(r) = renderers.get_mut(&name) {
+                            r.abort_transition();
+                        }
+                    }
+                }
+            }
         }
 
         // Render Loop for Transitions / Redraws
         for (name, r) in renderers.iter_mut() {
-            if r.needs_redraw || r.transition_active || r.valid_content_type == crate::queue::ContentType::Video {
+            if r.needs_redraw
+                || r.transition_active
+                || r.valid_content_type == crate::queue::ContentType::Video
+            {
                 let _ = r.render(renderer::BackendContext::X11, loop_start);
                 if !first_frame_recorded_x11 {
                     metrics.record_first_frame();
@@ -1331,9 +1581,11 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
                 }
             }
         }
-        
+
         // Ensure X11 commands are sent - only if we actually rendered something
-        let needs_flush = renderers.values().any(|r| r.needs_redraw || r.transition_active);
+        let needs_flush = renderers
+            .values()
+            .any(|r| r.needs_redraw || r.transition_active);
         if needs_flush {
             let _ = backend.conn.flush();
         }
@@ -1341,7 +1593,7 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
         // Record frame time
         let frame_time = loop_start.elapsed();
         metrics.record_frame_time(frame_time);
-        
+
         // Cleanup texture pool periodically (every 3 seconds for more aggressive cleanup)
         if last_pool_cleanup_x11.elapsed().as_secs() >= 3 {
             if let Some(ctx) = &wgpu_ctx {
@@ -1349,25 +1601,25 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
             }
             last_pool_cleanup_x11 = Instant::now();
         }
-        
+
         // Process directory watcher events (cache invalidation)
         if let Some(ref mut watcher) = dir_watcher {
             let _ = watcher.process_events().await;
         }
-        
+
         // Flush stats every 5 seconds (batched writes)
         if last_stats_flush_x11.elapsed().as_secs() >= 5 {
             let _ = monitor_manager.flush_all_stats();
             last_stats_flush_x11 = Instant::now();
         }
-        
+
         // Log metrics summary every 10 seconds
         if last_metrics_log.elapsed().as_secs() >= 10 {
             // Record resource counts for leak detection
             if let Some(ctx) = &wgpu_ctx {
                 let texture_count = ctx.texture_pool.lock().values().map(|v| v.len()).sum();
-                let pipeline_count = ctx.transition_pipelines.lock().len() 
-                    + ctx.blit_pipelines.lock().len() 
+                let pipeline_count = ctx.transition_pipelines.lock().len()
+                    + ctx.blit_pipelines.lock().len()
                     + ctx.mipmap_pipelines.lock().len();
                 metrics.record_texture_count(texture_count);
                 metrics.record_pipeline_count(pipeline_count);
@@ -1380,12 +1632,15 @@ async fn run_x11_loop(config: orchestration::Config, log_level: Option<u8>, gstr
         if elapsed < target_frame_time {
             tokio::time::sleep(target_frame_time - elapsed).await;
         }
-        if let Some(ctx) = &wgpu_ctx { ctx.device.poll(wgpu::Maintain::Poll); }
+        if let Some(ctx) = &wgpu_ctx {
+            ctx.device.poll(wgpu::Maintain::Poll);
+        }
     }
-    
+
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_command(
     req: Request,
     monitor_manager: &mut monitor_manager::MonitorManager,
@@ -1400,19 +1655,39 @@ async fn handle_command(
 ) -> Response {
     match req {
         Request::QueryOutputs => {
-             let outputs = renderers.iter().map(|(n, r)| kaleidux_common::OutputInfo {
-                 name: n.clone(),
-                 width: r.config.width,
-                 height: r.config.height,
-                 current_wallpaper: monitor_manager.outputs.get(n).and_then(|o| o.current_path.as_ref().map(|p| p.display().to_string())),
-             }).collect();
-             Response::OutputInfo(outputs)
+            let outputs = renderers
+                .iter()
+                .map(|(n, r)| kaleidux_common::OutputInfo {
+                    name: n.clone(),
+                    width: r.config.width,
+                    height: r.config.height,
+                    current_wallpaper: monitor_manager
+                        .outputs
+                        .get(n)
+                        .and_then(|o| o.current_path.as_ref().map(|p| p.display().to_string())),
+                })
+                .collect();
+            Response::OutputInfo(outputs)
         }
         Request::Next { output } => {
             let changes = monitor_manager.handle_next(output);
             let batch = rand::random::<u64>();
             for (name, (path, content_type)) in changes {
-                switch_wallpaper_content(&name, &path, content_type, next_session_id, frame_tx, monitor_manager, renderers, video_players, Some(batch), Some(loop_start), image_tx, player_tx, "NEXT");
+                switch_wallpaper_content(
+                    &name,
+                    &path,
+                    content_type,
+                    next_session_id,
+                    frame_tx,
+                    monitor_manager,
+                    renderers,
+                    video_players,
+                    Some(batch),
+                    Some(loop_start),
+                    image_tx,
+                    player_tx,
+                    "NEXT",
+                );
             }
             Response::Ok
         }
@@ -1420,7 +1695,21 @@ async fn handle_command(
             let changes = monitor_manager.handle_prev(output);
             let batch = rand::random::<u64>();
             for (name, (path, content_type)) in changes {
-                switch_wallpaper_content(&name, &path, content_type, next_session_id, frame_tx, monitor_manager, renderers, video_players, Some(batch), Some(loop_start), image_tx, player_tx, "PREV");
+                switch_wallpaper_content(
+                    &name,
+                    &path,
+                    content_type,
+                    next_session_id,
+                    frame_tx,
+                    monitor_manager,
+                    renderers,
+                    video_players,
+                    Some(batch),
+                    Some(loop_start),
+                    image_tx,
+                    player_tx,
+                    "PREV",
+                );
             }
             Response::Ok
         }
@@ -1431,16 +1720,18 @@ async fn handle_command(
         Request::Playlist(cmd) => monitor_manager.handle_playlist_command(cmd),
         Request::Blacklist(cmd) => monitor_manager.handle_blacklist_command(cmd),
         Request::LoveitList => Response::LoveitList(monitor_manager.get_loveitlist()),
-        Request::Love { path, multiplier } => {
-             monitor_manager.love_file(path, multiplier).map(|_| Response::Ok).unwrap_or_else(|e| Response::Error(e.to_string()))
-        }
-        Request::Unlove { path } => {
-             monitor_manager.unlove_file(path).map(|_| Response::Ok).unwrap_or_else(|e| Response::Error(e.to_string()))
-        }
+        Request::Love { path, multiplier } => monitor_manager
+            .love_file(path, multiplier)
+            .map(|_| Response::Ok)
+            .unwrap_or_else(|e| Response::Error(e.to_string())),
+        Request::Unlove { path } => monitor_manager
+            .unlove_file(path)
+            .map(|_| Response::Ok)
+            .unwrap_or_else(|e| Response::Error(e.to_string())),
         Request::History { output } => Response::History(monitor_manager.get_history(output)),
         Request::Reload => {
             info!("Reloading configuration...");
-             match orchestration::Config::load().await {
+            match orchestration::Config::load().await {
                 Ok(new_config) => {
                     monitor_manager.update_config(new_config);
                     // Refresh renderers with new config
@@ -1458,6 +1749,6 @@ async fn handle_command(
                 }
             }
         }
-        _ => Response::Ok
+        _ => Response::Ok,
     }
 }

--- a/kaleidux-daemon/src/metrics.rs
+++ b/kaleidux-daemon/src/metrics.rs
@@ -1,68 +1,68 @@
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Performance metrics for monitoring
 pub struct PerformanceMetrics {
     // Frame timing
     pub frame_times: Arc<parking_lot::Mutex<VecDeque<f64>>>, // Last 100 frame times in ms
-    pub avg_frame_time: Arc<AtomicU64>, // Average in microseconds
-    
+    pub avg_frame_time: Arc<AtomicU64>,                      // Average in microseconds
+
     // Texture pool stats
     pub texture_pool_hits: Arc<AtomicU64>,
     pub texture_pool_misses: Arc<AtomicU64>,
-    
+
     // Transition stats
     pub transition_count: Arc<AtomicU64>,
     pub transition_times: Arc<parking_lot::Mutex<VecDeque<f64>>>, // Last 50 transition times in ms
-    
+
     // Video stats
     pub video_first_frame_times: Arc<parking_lot::Mutex<VecDeque<f64>>>, // Last 20 first frame times in ms
-    
+
     // Cache stats
     pub cache_hits: Arc<AtomicU64>,
     pub cache_misses: Arc<AtomicU64>,
-    
+
     // Resource leak detection
     pub texture_count_samples: Arc<parking_lot::Mutex<VecDeque<(std::time::Instant, usize)>>>, // (timestamp, count)
     pub pipeline_count_samples: Arc<parking_lot::Mutex<VecDeque<(std::time::Instant, usize)>>>, // (timestamp, count)
-    
+
     // Channel buffer tracking for memory leak detection
     pub frame_channel_size_samples: Arc<parking_lot::Mutex<VecDeque<(std::time::Instant, usize)>>>, // (timestamp, frames in channel)
     pub image_channel_size_samples: Arc<parking_lot::Mutex<VecDeque<(std::time::Instant, usize)>>>, // (timestamp, images in channel)
-    
+
     // Uptime tracking
     start_time: std::time::Instant,
-    
+
     // Startup metrics
     startup_metrics: Arc<parking_lot::Mutex<StartupMetrics>>,
-    
+
     // Memory usage over time
     memory_samples: Arc<parking_lot::Mutex<VecDeque<(std::time::Instant, f64)>>>, // (timestamp, MB)
-    
+
     // GPU utilization over time
     gpu_util_samples: Arc<parking_lot::Mutex<VecDeque<(std::time::Instant, f64)>>>, // (timestamp, %)
-    
+
     // Error tracking
     error_count: Arc<AtomicU64>,
     error_samples: Arc<parking_lot::Mutex<VecDeque<(std::time::Instant, String)>>>, // (timestamp, error_type)
-    
+
     // Component CPU tracking (time spent in each component in milliseconds)
     renderer_cpu_time: Arc<AtomicU64>, // Total CPU time in microseconds
-    video_cpu_time: Arc<AtomicU64>, // Total CPU time in microseconds
+    video_cpu_time: Arc<AtomicU64>,    // Total CPU time in microseconds
     file_discovery_cpu_time: Arc<AtomicU64>, // Total CPU time in microseconds
     shader_compile_cpu_time: Arc<AtomicU64>, // Total CPU time in microseconds
-    
+
     // Component operation counts
     renderer_ops: Arc<AtomicU64>,
     video_ops: Arc<AtomicU64>,
     file_discovery_ops: Arc<AtomicU64>,
     shader_compile_ops: Arc<AtomicU64>,
-    
+
     // Component CPU time samples (for averaging)
     renderer_samples: Arc<parking_lot::Mutex<VecDeque<f64>>>, // Last 100 renderer times in ms
-    video_samples: Arc<parking_lot::Mutex<VecDeque<f64>>>, // Last 100 video times in ms
+    video_samples: Arc<parking_lot::Mutex<VecDeque<f64>>>,    // Last 100 video times in ms
     file_discovery_samples: Arc<parking_lot::Mutex<VecDeque<f64>>>, // Last 20 file discovery times in ms
     shader_compile_samples: Arc<parking_lot::Mutex<VecDeque<f64>>>, // Last 50 shader compile times in ms
 }
@@ -91,8 +91,12 @@ impl PerformanceMetrics {
             cache_misses: Arc::new(AtomicU64::new(0)),
             texture_count_samples: Arc::new(parking_lot::Mutex::new(VecDeque::with_capacity(100))),
             pipeline_count_samples: Arc::new(parking_lot::Mutex::new(VecDeque::with_capacity(100))),
-            frame_channel_size_samples: Arc::new(parking_lot::Mutex::new(VecDeque::with_capacity(100))),
-            image_channel_size_samples: Arc::new(parking_lot::Mutex::new(VecDeque::with_capacity(100))),
+            frame_channel_size_samples: Arc::new(parking_lot::Mutex::new(VecDeque::with_capacity(
+                100,
+            ))),
+            image_channel_size_samples: Arc::new(parking_lot::Mutex::new(VecDeque::with_capacity(
+                100,
+            ))),
             start_time: std::time::Instant::now(),
             startup_metrics: Arc::new(parking_lot::Mutex::new(StartupMetrics {
                 startup_start: Some(std::time::Instant::now()),
@@ -120,7 +124,7 @@ impl PerformanceMetrics {
             shader_compile_samples: Arc::new(parking_lot::Mutex::new(VecDeque::with_capacity(50))),
         }
     }
-    
+
     pub fn record_error(&self, error_type: &str) {
         self.error_count.fetch_add(1, Ordering::Relaxed);
         let mut samples = self.error_samples.lock();
@@ -129,7 +133,7 @@ impl PerformanceMetrics {
             samples.pop_front();
         }
     }
-    
+
     pub fn get_error_rate(&self) -> f64 {
         let samples = self.error_samples.lock();
         if samples.len() < 2 {
@@ -146,11 +150,11 @@ impl PerformanceMetrics {
             0.0
         }
     }
-    
+
     pub fn get_error_count(&self) -> u64 {
         self.error_count.load(Ordering::Relaxed)
     }
-    
+
     pub fn record_gpu_utilization(&self, percent: f64) {
         let mut samples = self.gpu_util_samples.lock();
         samples.push_back((std::time::Instant::now(), percent));
@@ -158,7 +162,7 @@ impl PerformanceMetrics {
             samples.pop_front();
         }
     }
-    
+
     pub fn get_avg_gpu_utilization(&self) -> Option<f64> {
         let samples = self.gpu_util_samples.lock();
         if samples.is_empty() {
@@ -167,7 +171,7 @@ impl PerformanceMetrics {
         let sum: f64 = samples.iter().map(|(_, p)| *p).sum();
         Some(sum / samples.len() as f64)
     }
-    
+
     pub fn record_memory_usage(&self, mb: f64) {
         let mut samples = self.memory_samples.lock();
         samples.push_back((std::time::Instant::now(), mb));
@@ -175,7 +179,7 @@ impl PerformanceMetrics {
             samples.pop_front();
         }
     }
-    
+
     pub fn get_memory_growth_rate(&self) -> Option<f64> {
         let samples = self.memory_samples.lock();
         if samples.len() < 2 {
@@ -193,32 +197,34 @@ impl PerformanceMetrics {
             None
         }
     }
-    
+
     pub fn get_current_memory(&self) -> Option<f64> {
         self.memory_samples.lock().back().map(|(_, mb)| *mb)
     }
-    
+
     pub fn get_peak_memory(&self) -> Option<f64> {
-        self.memory_samples.lock().iter()
+        self.memory_samples
+            .lock()
+            .iter()
             .filter_map(|(_, mb)| if mb.is_finite() { Some(*mb) } else { None })
             .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
     }
-    
+
     pub fn record_startup_start(&self) {
         let mut metrics = self.startup_metrics.lock();
         metrics.startup_start = Some(std::time::Instant::now());
     }
-    
+
     pub fn record_gstreamer_init(&self, duration: Duration) {
         let mut metrics = self.startup_metrics.lock();
         metrics.gstreamer_init_duration = Some(duration);
     }
-    
+
     pub fn record_wgpu_init(&self, duration: Duration) {
         let mut metrics = self.startup_metrics.lock();
         metrics.wgpu_init_duration = Some(duration);
     }
-    
+
     /// Record CPU time spent in renderer operations
     pub fn record_renderer_cpu_time(&self, duration: Duration) {
         let us = duration.as_micros() as u64;
@@ -231,7 +237,7 @@ impl PerformanceMetrics {
             samples.pop_front();
         }
     }
-    
+
     /// Record CPU time spent in video operations
     pub fn record_video_cpu_time(&self, duration: Duration) {
         let us = duration.as_micros() as u64;
@@ -244,11 +250,12 @@ impl PerformanceMetrics {
             samples.pop_front();
         }
     }
-    
+
     /// Record CPU time spent in file discovery
     pub fn record_file_discovery_cpu_time(&self, duration: Duration) {
         let us = duration.as_micros() as u64;
-        self.file_discovery_cpu_time.fetch_add(us, Ordering::Relaxed);
+        self.file_discovery_cpu_time
+            .fetch_add(us, Ordering::Relaxed);
         self.file_discovery_ops.fetch_add(1, Ordering::Relaxed);
         let ms = duration.as_secs_f64() * 1000.0;
         let mut samples = self.file_discovery_samples.lock();
@@ -257,11 +264,12 @@ impl PerformanceMetrics {
             samples.pop_front();
         }
     }
-    
+
     /// Record CPU time spent in shader compilation
     pub fn record_shader_compile_cpu_time(&self, duration: Duration) {
         let us = duration.as_micros() as u64;
-        self.shader_compile_cpu_time.fetch_add(us, Ordering::Relaxed);
+        self.shader_compile_cpu_time
+            .fetch_add(us, Ordering::Relaxed);
         self.shader_compile_ops.fetch_add(1, Ordering::Relaxed);
         let ms = duration.as_secs_f64() * 1000.0;
         let mut samples = self.shader_compile_samples.lock();
@@ -270,7 +278,7 @@ impl PerformanceMetrics {
             samples.pop_front();
         }
     }
-    
+
     /// Get average CPU time per renderer operation (in ms)
     #[allow(dead_code)]
     pub fn get_avg_renderer_cpu_time_ms(&self) -> f64 {
@@ -281,7 +289,7 @@ impl PerformanceMetrics {
         let total_us = self.renderer_cpu_time.load(Ordering::Relaxed);
         (total_us as f64 / ops as f64) / 1000.0
     }
-    
+
     /// Get average CPU time per video operation (in ms)
     #[allow(dead_code)]
     pub fn get_avg_video_cpu_time_ms(&self) -> f64 {
@@ -292,7 +300,7 @@ impl PerformanceMetrics {
         let total_us = self.video_cpu_time.load(Ordering::Relaxed);
         (total_us as f64 / ops as f64) / 1000.0
     }
-    
+
     /// Get average CPU time per file discovery operation (in ms)
     pub fn get_avg_file_discovery_cpu_time_ms(&self) -> f64 {
         let ops = self.file_discovery_ops.load(Ordering::Relaxed);
@@ -302,7 +310,7 @@ impl PerformanceMetrics {
         let total_us = self.file_discovery_cpu_time.load(Ordering::Relaxed);
         (total_us as f64 / ops as f64) / 1000.0
     }
-    
+
     /// Get average CPU time per shader compile operation (in ms)
     pub fn get_avg_shader_compile_cpu_time_ms(&self) -> f64 {
         let ops = self.shader_compile_ops.load(Ordering::Relaxed);
@@ -312,7 +320,7 @@ impl PerformanceMetrics {
         let total_us = self.shader_compile_cpu_time.load(Ordering::Relaxed);
         (total_us as f64 / ops as f64) / 1000.0
     }
-    
+
     /// Get recent average renderer CPU time from samples (in ms)
     pub fn get_recent_avg_renderer_cpu_time_ms(&self) -> f64 {
         let samples = self.renderer_samples.lock();
@@ -321,7 +329,7 @@ impl PerformanceMetrics {
         }
         samples.iter().sum::<f64>() / samples.len() as f64
     }
-    
+
     /// Get recent average video CPU time from samples (in ms)
     pub fn get_recent_avg_video_cpu_time_ms(&self) -> f64 {
         let samples = self.video_samples.lock();
@@ -330,7 +338,7 @@ impl PerformanceMetrics {
         }
         samples.iter().sum::<f64>() / samples.len() as f64
     }
-    
+
     pub fn record_first_frame(&self) {
         let mut metrics = self.startup_metrics.lock();
         if let Some(start) = metrics.startup_start {
@@ -339,18 +347,18 @@ impl PerformanceMetrics {
             }
         }
     }
-    
+
     pub fn record_full_init(&self) {
         let mut metrics = self.startup_metrics.lock();
         if let Some(start) = metrics.startup_start {
             metrics.time_to_full_init = Some(start.elapsed());
         }
     }
-    
+
     pub fn log_startup_summary(&self) {
         let metrics = self.startup_metrics.lock();
         let mut parts = Vec::new();
-        
+
         if let Some(d) = metrics.gstreamer_init_duration {
             parts.push(format!("GStreamer: {:.2}ms", d.as_secs_f64() * 1000.0));
         }
@@ -366,27 +374,36 @@ impl PerformanceMetrics {
         if let Some(d) = metrics.time_to_full_init {
             parts.push(format!("Full init: {:.2}ms", d.as_secs_f64() * 1000.0));
         }
-        
+
         if !parts.is_empty() {
             tracing::info!("[STARTUP] {}", parts.join(" | "));
         }
     }
-    
+
     pub fn get_memory_info(&self) -> String {
-        let current = self.get_current_memory().map(|m| format!("{:.1}MB", m)).unwrap_or_else(|| "N/A".to_string());
-        let peak = self.get_peak_memory().map(|m| format!("{:.1}MB", m)).unwrap_or_else(|| "N/A".to_string());
-        let growth = self.get_memory_growth_rate().map(|r| format!("{:.2}MB/s", r)).unwrap_or_else(|| "N/A".to_string());
+        let current = self
+            .get_current_memory()
+            .map(|m| format!("{:.1}MB", m))
+            .unwrap_or_else(|| "N/A".to_string());
+        let peak = self
+            .get_peak_memory()
+            .map(|m| format!("{:.1}MB", m))
+            .unwrap_or_else(|| "N/A".to_string());
+        let growth = self
+            .get_memory_growth_rate()
+            .map(|r| format!("{:.2}MB/s", r))
+            .unwrap_or_else(|| "N/A".to_string());
         format!("current={} peak={} growth={}", current, peak, growth)
     }
-    
+
     pub fn get_uptime(&self) -> std::time::Duration {
         self.start_time.elapsed()
     }
-    
+
     pub fn get_uptime_seconds(&self) -> u64 {
         self.get_uptime().as_secs()
     }
-    
+
     pub fn record_frame_time(&self, duration: std::time::Duration) {
         let ms = duration.as_secs_f64() * 1000.0;
         let mut times = self.frame_times.lock();
@@ -394,20 +411,21 @@ impl PerformanceMetrics {
         if times.len() > 100 {
             times.pop_front();
         }
-        
+
         // Update average (in microseconds)
         let avg = times.iter().sum::<f64>() / times.len() as f64;
-        self.avg_frame_time.store((avg * 1000.0) as u64, Ordering::Relaxed);
+        self.avg_frame_time
+            .store((avg * 1000.0) as u64, Ordering::Relaxed);
     }
-    
+
     pub fn record_texture_pool_hit(&self) {
         self.texture_pool_hits.fetch_add(1, Ordering::Relaxed);
     }
-    
+
     pub fn record_texture_pool_miss(&self) {
         self.texture_pool_misses.fetch_add(1, Ordering::Relaxed);
     }
-    
+
     pub fn record_transition(&self, duration: std::time::Duration) {
         self.transition_count.fetch_add(1, Ordering::Relaxed);
         let ms = duration.as_secs_f64() * 1000.0;
@@ -417,7 +435,7 @@ impl PerformanceMetrics {
             times.pop_front();
         }
     }
-    
+
     pub fn record_video_first_frame(&self, duration: std::time::Duration) {
         let ms = duration.as_secs_f64() * 1000.0;
         let mut times = self.video_first_frame_times.lock();
@@ -426,15 +444,15 @@ impl PerformanceMetrics {
             times.pop_front();
         }
     }
-    
+
     pub fn record_cache_hit(&self) {
         self.cache_hits.fetch_add(1, Ordering::Relaxed);
     }
-    
+
     pub fn record_cache_miss(&self) {
         self.cache_misses.fetch_add(1, Ordering::Relaxed);
     }
-    
+
     pub fn get_texture_pool_hit_rate(&self) -> f64 {
         let hits = self.texture_pool_hits.load(Ordering::Relaxed) as f64;
         let misses = self.texture_pool_misses.load(Ordering::Relaxed) as f64;
@@ -445,7 +463,7 @@ impl PerformanceMetrics {
             hits / total
         }
     }
-    
+
     pub fn get_cache_hit_rate(&self) -> f64 {
         let hits = self.cache_hits.load(Ordering::Relaxed) as f64;
         let misses = self.cache_misses.load(Ordering::Relaxed) as f64;
@@ -456,11 +474,11 @@ impl PerformanceMetrics {
             hits / total
         }
     }
-    
+
     pub fn get_avg_frame_time_ms(&self) -> f64 {
         self.avg_frame_time.load(Ordering::Relaxed) as f64 / 1000.0
     }
-    
+
     fn get_percentile(&self, percentile: f64) -> f64 {
         let times = self.frame_times.lock();
         if times.is_empty() {
@@ -472,21 +490,24 @@ impl PerformanceMetrics {
         }
         sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
         let idx = (sorted.len() as f64 * percentile) as usize;
-        sorted.get(idx.min(sorted.len() - 1)).copied().unwrap_or(0.0)
+        sorted
+            .get(idx.min(sorted.len() - 1))
+            .copied()
+            .unwrap_or(0.0)
     }
-    
+
     pub fn get_p50_frame_time_ms(&self) -> f64 {
         self.get_percentile(0.50)
     }
-    
+
     pub fn get_p95_frame_time_ms(&self) -> f64 {
         self.get_percentile(0.95)
     }
-    
+
     pub fn get_p99_frame_time_ms(&self) -> f64 {
         self.get_percentile(0.99)
     }
-    
+
     pub fn record_texture_count(&self, count: usize) {
         let mut samples = self.texture_count_samples.lock();
         samples.push_back((std::time::Instant::now(), count));
@@ -494,7 +515,7 @@ impl PerformanceMetrics {
             samples.pop_front();
         }
     }
-    
+
     pub fn record_pipeline_count(&self, count: usize) {
         let mut samples = self.pipeline_count_samples.lock();
         samples.push_back((std::time::Instant::now(), count));
@@ -502,7 +523,7 @@ impl PerformanceMetrics {
             samples.pop_front();
         }
     }
-    
+
     pub fn record_frame_channel_size(&self, size: usize) {
         let mut samples = self.frame_channel_size_samples.lock();
         samples.push_back((std::time::Instant::now(), size));
@@ -510,7 +531,7 @@ impl PerformanceMetrics {
             samples.pop_front();
         }
     }
-    
+
     pub fn record_image_channel_size(&self, size: usize) {
         let mut samples = self.image_channel_size_samples.lock();
         samples.push_back((std::time::Instant::now(), size));
@@ -518,61 +539,81 @@ impl PerformanceMetrics {
             samples.pop_front();
         }
     }
-    
+
     pub fn check_resource_leaks(&self) -> Option<String> {
         let texture_samples = self.texture_count_samples.lock();
         let pipeline_samples = self.pipeline_count_samples.lock();
-        
+
         if texture_samples.len() < 10 || pipeline_samples.len() < 10 {
             return None; // Not enough data
         }
-        
+
         let mut warnings = Vec::new();
-        
+
         // Check texture count growth
         if let (Some(first), Some(last)) = (texture_samples.front(), texture_samples.back()) {
             let growth = last.1.saturating_sub(first.1);
             let duration = last.0.duration_since(first.0).as_secs();
             if growth > 50 && duration > 60 {
                 let growth_rate = growth as f64 / duration as f64;
-                warnings.push(format!("Texture count grew by {} over {}s ({:.2}/s)", growth, duration, growth_rate));
+                warnings.push(format!(
+                    "Texture count grew by {} over {}s ({:.2}/s)",
+                    growth, duration, growth_rate
+                ));
             }
         }
-        
+
         // Check pipeline count growth
         if let (Some(first), Some(last)) = (pipeline_samples.front(), pipeline_samples.back()) {
             let growth = last.1.saturating_sub(first.1);
             let duration = last.0.duration_since(first.0).as_secs();
             if growth > 20 && duration > 60 {
                 let growth_rate = growth as f64 / duration as f64;
-                warnings.push(format!("Pipeline count grew by {} over {}s ({:.2}/s)", growth, duration, growth_rate));
+                warnings.push(format!(
+                    "Pipeline count grew by {} over {}s ({:.2}/s)",
+                    growth, duration, growth_rate
+                ));
             }
         }
-        
+
         if warnings.is_empty() {
             None
         } else {
             Some(warnings.join("; "))
         }
     }
-    
+
     pub fn log_summary(&self) {
         let leak_warning = self.check_resource_leaks();
-        let leak_msg = leak_warning.map(|w| format!(" | LEAK WARNING: {}", w)).unwrap_or_default();
-        
+        let leak_msg = leak_warning
+            .map(|w| format!(" | LEAK WARNING: {}", w))
+            .unwrap_or_default();
+
         let uptime_secs = self.get_uptime_seconds();
         let uptime_str = if uptime_secs < 60 {
             format!("{}s", uptime_secs)
         } else if uptime_secs < 3600 {
             format!("{}m{}s", uptime_secs / 60, uptime_secs % 60)
         } else {
-            format!("{}h{}m{}s", uptime_secs / 3600, (uptime_secs % 3600) / 60, uptime_secs % 60)
+            format!(
+                "{}h{}m{}s",
+                uptime_secs / 3600,
+                (uptime_secs % 3600) / 60,
+                uptime_secs % 60
+            )
         };
-        
+
         let memory_info = self.get_memory_info();
-        let gpu_info = self.get_avg_gpu_utilization().map(|g| format!("{:.1}%", g)).unwrap_or_else(|| "N/A".to_string());
-        let error_info = format!("count={} rate={:.3}/s", self.get_error_count(), self.get_error_rate());
-        
+        let gpu_info = self
+            .get_avg_gpu_utilization()
+            .map(|g| format!("{:.1}%", g))
+            .unwrap_or_else(|| "N/A".to_string());
+        let error_info = format!(
+            "count={} rate={:.3}/s",
+            self.get_error_count(),
+            self.get_error_rate()
+        );
+
         // Component CPU stats
         let renderer_avg = self.get_recent_avg_renderer_cpu_time_ms();
         let video_avg = self.get_recent_avg_video_cpu_time_ms();
@@ -582,7 +623,7 @@ impl PerformanceMetrics {
             "renderer={:.2}ms video={:.2}ms file_disc={:.2}ms shader={:.2}ms",
             renderer_avg, video_avg, file_disc_avg, shader_avg
         );
-        
+
         tracing::info!(
             "[METRICS] Uptime: {} | Memory: {} | GPU: {} | Errors: {} | Frame time: avg={:.2}ms p50={:.2}ms p95={:.2}ms p99={:.2}ms | Texture pool: hit_rate={:.1}% ({}/{}) | Cache: hit_rate={:.1}% ({}/{}) | Transitions: {} | Component CPU: {}{}",
             uptime_str,

--- a/kaleidux-daemon/src/orchestration.rs
+++ b/kaleidux-daemon/src/orchestration.rs
@@ -1,9 +1,9 @@
+use anyhow::{Context, Result};
+use regex::Regex;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
-use regex::Regex;
-use anyhow::{Result, Context};
 
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
@@ -143,13 +143,14 @@ impl Config {
             return Ok(Self::default());
         }
 
-        let content = tokio::fs::read_to_string(&config_path).await
+        let content = tokio::fs::read_to_string(&config_path)
+            .await
             .with_context(|| format!("Failed to read config file: {:?}", config_path))?;
-        
+
         // Parse as raw TOML table first to work around serde(flatten) issues
-        let table: toml::Table = toml::from_str(&content)
-            .with_context(|| "Failed to parse config TOML")?;
-        
+        let table: toml::Table =
+            toml::from_str(&content).with_context(|| "Failed to parse config TOML")?;
+
         // Extract reserved sections
         let global: GlobalConfig = if let Some(v) = table.get("global") {
             v.clone().try_into().unwrap_or_else(|e| {
@@ -159,7 +160,7 @@ impl Config {
         } else {
             GlobalConfig::default()
         };
-        
+
         let any: PartialOutputConfig = if let Some(v) = table.get("any") {
             v.clone().try_into().unwrap_or_else(|e| {
                 tracing::error!("Failed to parse [any] config section: {}", e);
@@ -168,7 +169,7 @@ impl Config {
         } else {
             PartialOutputConfig::default()
         };
-        
+
         // Collect remaining sections as per-output configs
         let mut outputs = HashMap::new();
         let mut config_errors = Vec::new();
@@ -179,33 +180,41 @@ impl Config {
                         outputs.insert(key.clone(), cfg);
                     }
                     Err(e) => {
-                        let error_msg = format!("Failed to parse output config for [{}]: {}", key, e);
+                        let error_msg =
+                            format!("Failed to parse output config for [{}]: {}", key, e);
                         tracing::error!("{}", error_msg);
                         config_errors.push(error_msg);
                     }
                 }
             }
         }
-        
+
         if !config_errors.is_empty() {
-            tracing::warn!("{} output configuration section(s) had errors and were skipped", config_errors.len());
+            tracing::warn!(
+                "{} output configuration section(s) had errors and were skipped",
+                config_errors.len()
+            );
         }
-        
+
         tracing::info!("Loaded config with {} output overrides", outputs.len());
-        
-        Ok(Config { global, any, outputs })
+
+        Ok(Config {
+            global,
+            any,
+            outputs,
+        })
     }
 
     pub fn get_config_for_output(&self, name: &str, description: &str) -> OutputConfig {
         // 1. Start with global defaults
         let mut final_config = PartialOutputConfig {
             path: None,
-            duration: None, 
+            duration: None,
             video_ratio: self.global.video_ratio,
             transition: None,
             transition_time: self.global.transition_time,
             volume: self.global.volume,
-            sorting: self.global.sorting.clone(),
+            sorting: self.global.sorting,
             layer: None,
             default_playlist: self.global.default_playlist.clone(),
         };
@@ -216,8 +225,8 @@ impl Config {
         // 3. Match specific output
         let mut matched = None;
         for (key, val) in &self.outputs {
-            if key.starts_with("re:") {
-                if let Ok(re) = Regex::new(&key[3..]) {
+            if let Some(stripped) = key.strip_prefix("re:") {
+                if let Ok(re) = Regex::new(stripped) {
                     if re.is_match(description) {
                         matched = Some(val);
                         break;
@@ -239,15 +248,33 @@ impl Config {
 
 impl PartialOutputConfig {
     fn merge(&mut self, other: &Self) {
-        if other.path.is_some() { self.path = other.path.clone(); }
-        if other.duration.is_some() { self.duration = other.duration; }
-        if other.video_ratio.is_some() { self.video_ratio = other.video_ratio; }
-        if other.transition.is_some() { self.transition = other.transition.clone(); }
-        if other.transition_time.is_some() { self.transition_time = other.transition_time; }
-        if other.volume.is_some() { self.volume = other.volume; }
-        if other.sorting.is_some() { self.sorting = other.sorting.clone(); }
-        if other.layer.is_some() { self.layer = other.layer.clone(); }
-        if other.default_playlist.is_some() { self.default_playlist = other.default_playlist.clone(); }
+        if other.path.is_some() {
+            self.path = other.path.clone();
+        }
+        if other.duration.is_some() {
+            self.duration = other.duration;
+        }
+        if other.video_ratio.is_some() {
+            self.video_ratio = other.video_ratio;
+        }
+        if other.transition.is_some() {
+            self.transition = other.transition.clone();
+        }
+        if other.transition_time.is_some() {
+            self.transition_time = other.transition_time;
+        }
+        if other.volume.is_some() {
+            self.volume = other.volume;
+        }
+        if other.sorting.is_some() {
+            self.sorting = other.sorting;
+        }
+        if other.layer.is_some() {
+            self.layer = other.layer.clone();
+        }
+        if other.default_playlist.is_some() {
+            self.default_playlist = other.default_playlist.clone();
+        }
     }
 
     fn into_output_config(self) -> OutputConfig {

--- a/kaleidux-daemon/src/renderer.rs
+++ b/kaleidux-daemon/src/renderer.rs
@@ -1,12 +1,12 @@
-use wgpu::{Instance, Surface, Adapter, Device, Queue, SurfaceConfiguration};
-use tracing::{info, debug, error, warn};
-use raw_window_handle::{HasWindowHandle, HasDisplayHandle};
-use std::sync::Arc;
-use bytemuck::{Pod, Zeroable};
-use std::collections::HashMap;
 use crate::shaders::Transition;
-use wayland_client::QueueHandle;
+use bytemuck::{Pod, Zeroable};
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use smithay_client_toolkit::shell::{wlr_layer::LayerSurface, WaylandSurface};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing::{debug, error, info, warn};
+use wayland_client::QueueHandle;
+use wgpu::{Adapter, Device, Instance, Queue, Surface, SurfaceConfiguration};
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Pod, Zeroable)]
@@ -55,7 +55,7 @@ impl PipelineLRU {
             max_size,
         }
     }
-    
+
     fn get(&mut self, key: &str) -> Option<Arc<wgpu::RenderPipeline>> {
         if let Some(pipeline) = self.pipelines.get(key).cloned() {
             // Move to back (most recently used)
@@ -66,7 +66,7 @@ impl PipelineLRU {
             None
         }
     }
-    
+
     fn insert(&mut self, key: String, pipeline: Arc<wgpu::RenderPipeline>) {
         // Remove if already exists
         if self.pipelines.contains_key(&key) {
@@ -84,11 +84,11 @@ impl PipelineLRU {
         self.pipelines.insert(key.clone(), pipeline);
         self.access_order.push_back(key);
     }
-    
+
     pub fn len(&self) -> usize {
         self.pipelines.len()
     }
-    
+
     #[allow(dead_code)]
     pub fn contains_key(&self, key: &str) -> bool {
         self.pipelines.contains_key(key)
@@ -102,7 +102,8 @@ pub struct WgpuContext {
     pub queue: Queue,
     pub transition_pipelines: parking_lot::Mutex<PipelineLRU>,
     pub blit_pipelines: parking_lot::Mutex<HashMap<wgpu::TextureFormat, Arc<wgpu::RenderPipeline>>>,
-    pub mipmap_pipelines: parking_lot::Mutex<HashMap<wgpu::TextureFormat, Arc<wgpu::RenderPipeline>>>,
+    pub mipmap_pipelines:
+        parking_lot::Mutex<HashMap<wgpu::TextureFormat, Arc<wgpu::RenderPipeline>>>,
     pub blit_bind_group_layout: wgpu::BindGroupLayout,
     pub transition_bind_group_layout: wgpu::BindGroupLayout,
     pub mipmap_bind_group_layout: wgpu::BindGroupLayout,
@@ -114,13 +115,15 @@ const MAX_PIPELINE_CACHE_SIZE: usize = 50;
 const MAX_TEXTURE_POOL_SIZE: usize = 50; // Global limit on total textures in pool
 
 impl WgpuContext {
-    pub async fn with_surface(window: Arc<impl HasWindowHandle + HasDisplayHandle + Sync + Send + 'static>) -> anyhow::Result<(Arc<Self>, Surface<'static>)> {
+    pub async fn with_surface(
+        window: Arc<impl HasWindowHandle + HasDisplayHandle + Sync + Send + 'static>,
+    ) -> anyhow::Result<(Arc<Self>, Surface<'static>)> {
         let instance = Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             ..Default::default()
         });
         let compatible_surface = instance.create_surface(window)?;
-        
+
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::HighPerformance,
@@ -130,7 +133,11 @@ impl WgpuContext {
             .await
             .ok_or_else(|| anyhow::anyhow!("Failed to find a suitable GPU adapter"))?;
 
-        info!("WGPU picked adapter: {:?} with backend: {:?}", adapter.get_info().name, adapter.get_info().backend);
+        info!(
+            "WGPU picked adapter: {:?} with backend: {:?}",
+            adapter.get_info().name,
+            adapter.get_info().backend
+        );
 
         let (device, queue) = adapter
             .request_device(
@@ -145,101 +152,104 @@ impl WgpuContext {
             .await?;
 
         // --- Shared Bind Group Layouts ---
-        let transition_bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("Transition Bind Group Layout"),
-            entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
+        let transition_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Transition Bind Group Layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
                     },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Texture {
-                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                        view_dimension: wgpu::TextureViewDimension::D2,
-                        multisampled: false,
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
                     },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Texture {
-                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                        view_dimension: wgpu::TextureViewDimension::D2,
-                        multisampled: false,
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
                     },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 3,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                    count: None,
-                },
-            ],
-        });
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 3,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
 
-        let blit_bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("Blit Bind Group Layout"),
-            entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::FRAGMENT | wgpu::ShaderStages::VERTEX,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
+        let blit_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Blit Bind Group Layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT | wgpu::ShaderStages::VERTEX,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
                     },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Texture {
-                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                        view_dimension: wgpu::TextureViewDimension::D2,
-                        multisampled: false,
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
                     },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                    count: None,
-                },
-            ],
-        });
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
 
-        let mipmap_bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("Mipmap Bind Group Layout"),
-            entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Texture {
-                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                        view_dimension: wgpu::TextureViewDimension::D2,
-                        multisampled: false,
+        let mipmap_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Mipmap Bind Group Layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
                     },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                    count: None,
-                },
-            ],
-        });
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
 
         Ok((
             Arc::new(Self {
@@ -247,7 +257,9 @@ impl WgpuContext {
                 adapter,
                 device,
                 queue,
-                transition_pipelines: parking_lot::Mutex::new(PipelineLRU::new(MAX_PIPELINE_CACHE_SIZE)),
+                transition_pipelines: parking_lot::Mutex::new(PipelineLRU::new(
+                    MAX_PIPELINE_CACHE_SIZE,
+                )),
                 blit_pipelines: parking_lot::Mutex::new(HashMap::new()),
                 mipmap_pipelines: parking_lot::Mutex::new(HashMap::new()),
                 blit_bind_group_layout,
@@ -255,7 +267,7 @@ impl WgpuContext {
                 mipmap_bind_group_layout,
                 texture_pool: parking_lot::Mutex::new(HashMap::new()),
             }),
-            compatible_surface
+            compatible_surface,
         ))
     }
 
@@ -265,47 +277,55 @@ impl WgpuContext {
         }
 
         debug!("[RENDER] Compiling blit pipeline for format: {:?}", format);
-        
-        let blit_shader = self.device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("Quad Shader"),
-            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/quad.wgsl").into()),
-        });
 
-        let blit_pipeline_layout = self.device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("Blit Pipeline Layout"),
-            bind_group_layouts: &[&self.blit_bind_group_layout],
-            push_constant_ranges: &[],
-        });
+        let blit_shader = self
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("Quad Shader"),
+                source: wgpu::ShaderSource::Wgsl(include_str!("shaders/quad.wgsl").into()),
+            });
 
-        let pipeline = self.device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("Blit Pipeline"),
-            layout: Some(&blit_pipeline_layout),
-            vertex: wgpu::VertexState {
-                module: &blit_shader,
-                entry_point: Some("vs_main"),
-                compilation_options: Default::default(),
-                buffers: &[],
-            },
-            fragment: Some(wgpu::FragmentState {
-                module: &blit_shader,
-                entry_point: Some("fs_blit"),
-                compilation_options: Default::default(),
-                targets: &[Some(wgpu::ColorTargetState {
-                    format,
-                    blend: Some(wgpu::BlendState::REPLACE),
-                    write_mask: wgpu::ColorWrites::ALL,
-                })],
-            }),
-            primitive: wgpu::PrimitiveState::default(),
-            depth_stencil: None,
-            multisample: wgpu::MultisampleState::default(),
-            multiview: None,
-            cache: None,
-        });
+        let blit_pipeline_layout =
+            self.device
+                .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                    label: Some("Blit Pipeline Layout"),
+                    bind_group_layouts: &[&self.blit_bind_group_layout],
+                    push_constant_ranges: &[],
+                });
+
+        let pipeline = self
+            .device
+            .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("Blit Pipeline"),
+                layout: Some(&blit_pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &blit_shader,
+                    entry_point: Some("vs_main"),
+                    compilation_options: Default::default(),
+                    buffers: &[],
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &blit_shader,
+                    entry_point: Some("fs_blit"),
+                    compilation_options: Default::default(),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format,
+                        blend: Some(wgpu::BlendState::REPLACE),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                }),
+                primitive: wgpu::PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            });
 
         let pipeline_arc = Arc::new(pipeline);
 
-        self.blit_pipelines.lock().insert(format, pipeline_arc.clone());
+        self.blit_pipelines
+            .lock()
+            .insert(format, pipeline_arc.clone());
         pipeline_arc
     }
 
@@ -314,62 +334,79 @@ impl WgpuContext {
             return pipe.clone();
         }
 
-        debug!("[RENDER] Compiling mipmap pipeline for format: {:?}", format);
-        
+        debug!(
+            "[RENDER] Compiling mipmap pipeline for format: {:?}",
+            format
+        );
+
         // Load mipmap.wgsl
-        let shader = self.device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("Mipmap Shader"),
-            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/mipmap.wgsl").into()),
-        });
+        let shader = self
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("Mipmap Shader"),
+                source: wgpu::ShaderSource::Wgsl(include_str!("shaders/mipmap.wgsl").into()),
+            });
 
-        let layout = self.device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("Mipmap Pipeline Layout"),
-            bind_group_layouts: &[&self.mipmap_bind_group_layout],
-            push_constant_ranges: &[],
-        });
+        let layout = self
+            .device
+            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Mipmap Pipeline Layout"),
+                bind_group_layouts: &[&self.mipmap_bind_group_layout],
+                push_constant_ranges: &[],
+            });
 
-        let pipeline = self.device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("Mipmap Pipeline"),
-            layout: Some(&layout),
-            vertex: wgpu::VertexState {
-                module: &shader,
-                entry_point: Some("vs_main"),
-                compilation_options: Default::default(),
-                buffers: &[],
-            },
-            fragment: Some(wgpu::FragmentState {
-                module: &shader,
-                entry_point: Some("fs_main"),
-                compilation_options: Default::default(),
-                targets: &[Some(wgpu::ColorTargetState {
-                    format,
-                    blend: Some(wgpu::BlendState::REPLACE),
-                    write_mask: wgpu::ColorWrites::ALL,
-                })],
-            }),
-            primitive: wgpu::PrimitiveState::default(),
-            depth_stencil: None,
-            multisample: wgpu::MultisampleState::default(),
-            multiview: None,
-            cache: None,
-        });
+        let pipeline = self
+            .device
+            .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("Mipmap Pipeline"),
+                layout: Some(&layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    compilation_options: Default::default(),
+                    buffers: &[],
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some("fs_main"),
+                    compilation_options: Default::default(),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format,
+                        blend: Some(wgpu::BlendState::REPLACE),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                }),
+                primitive: wgpu::PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            });
 
         let pipeline_arc = Arc::new(pipeline);
-        self.mipmap_pipelines.lock().insert(format, pipeline_arc.clone());
+        self.mipmap_pipelines
+            .lock()
+            .insert(format, pipeline_arc.clone());
         pipeline_arc
     }
-    
+
     /// Get a texture from the pool or create a new one
-    pub fn get_texture_from_pool(&self, width: u32, height: u32, usage: wgpu::TextureUsages, metrics: Option<&crate::metrics::PerformanceMetrics>) -> wgpu::Texture {
+    pub fn get_texture_from_pool(
+        &self,
+        width: u32,
+        height: u32,
+        usage: wgpu::TextureUsages,
+        metrics: Option<&crate::metrics::PerformanceMetrics>,
+    ) -> wgpu::Texture {
         let mut pool = self.texture_pool.lock();
         let key = (width, height);
-        
+
         // Try to find a texture in the pool
         if let Some(entries) = pool.get_mut(&key) {
             // Remove stale entries (older than 5 seconds) and find a fresh one
             let now = std::time::Instant::now();
             entries.retain(|e| now.duration_since(e.last_used).as_secs() < 5);
-            
+
             if let Some(entry) = entries.pop() {
                 if let Some(m) = metrics {
                     m.record_texture_pool_hit();
@@ -377,7 +414,7 @@ impl WgpuContext {
                 return entry.texture;
             }
         }
-        
+
         // No texture in pool, create new one
         if let Some(m) = metrics {
             m.record_texture_pool_miss();
@@ -397,23 +434,23 @@ impl WgpuContext {
             view_formats: &[],
         })
     }
-    
+
     /// Return a texture to the pool for reuse
     pub fn return_texture_to_pool(&self, texture: wgpu::Texture, width: u32, height: u32) {
         let mut pool = self.texture_pool.lock();
         let key = (width, height);
-        
+
         // Calculate total textures in pool
         let total_textures: usize = pool.values().map(|v| v.len()).sum();
-        
+
         // Check global limit first
         if total_textures >= MAX_TEXTURE_POOL_SIZE {
             // Pool is at global limit, drop this texture
             return;
         }
-        
+
         // Limit pool size per resolution to prevent unbounded growth
-        let entries = pool.entry(key).or_insert_with(Vec::new);
+        let entries = pool.entry(key).or_default();
         if entries.len() < 3 {
             entries.push(TexturePoolEntry {
                 texture,
@@ -422,12 +459,12 @@ impl WgpuContext {
         }
         // If pool is full for this resolution, texture is dropped (freed by WGPU)
     }
-    
+
     /// Clean up old textures from pool
     pub fn cleanup_texture_pool(&self) {
         let mut pool = self.texture_pool.lock();
         let now = std::time::Instant::now();
-        
+
         // 1. Collect all valid (non-expired) textures
         let mut all_entries: Vec<((u32, u32), TexturePoolEntry)> = Vec::new();
         let old_pool = std::mem::take(&mut *pool);
@@ -438,7 +475,7 @@ impl WgpuContext {
                 }
             }
         }
-        
+
         // 2. If over global limit, sort and truncate
         if all_entries.len() > MAX_TEXTURE_POOL_SIZE {
             // Sort oldest first (smallest Instant)
@@ -447,7 +484,7 @@ impl WgpuContext {
             let keep_start = all_entries.len() - MAX_TEXTURE_POOL_SIZE;
             all_entries.drain(0..keep_start);
         }
-        
+
         // 3. Re-populate pool
         for (key, entry) in all_entries {
             pool.entry(key).or_default().push(entry);
@@ -470,7 +507,7 @@ pub struct Renderer {
     uniform_buffer: wgpu::Buffer,
     sampler_linear: wgpu::Sampler,
     composition_texture: Option<wgpu::Texture>,
-    
+
     current_texture: Option<wgpu::Texture>,
     current_aspect: f32,
     prev_texture: Option<wgpu::Texture>,
@@ -479,43 +516,49 @@ pub struct Renderer {
     pub transition_start_time: Option<std::time::Instant>,
     pub transition_active: bool, // Explicit flag tracking if transition is active (following wpaperd pattern)
     pub transition_just_completed: bool, // Flag set when transition completes, cleared by main loop
-    
+
     // Transition Settings
     pub active_transition: Transition,
     pub transition_duration: f32,
     pub transition_stats: Option<TransitionStats>,
-    
+
     // Texture Reuse
     current_texture_size: Option<(u32, u32)>,
     current_texture_view: Option<wgpu::TextureView>,
     prev_texture_view: Option<wgpu::TextureView>,
     composition_texture_view: Option<wgpu::TextureView>,
-    
+
     // Cached Bind Groups to avoid per-frame creation overhead
     transition_bind_group: Option<wgpu::BindGroup>,
     blit_bind_group: Option<wgpu::BindGroup>,
     blit_source_is_composition: bool, // Helps track which blit BG is currently cached
     blit_source_is_prev: bool,        // Helps track if it was prev or current
     transition_rendered_this_frame: bool, // Track if transition shader ran successfully this frame
-    
+
     // Content Type state to prevent race conditions (stale video frames overwriting images)
     pub valid_content_type: crate::queue::ContentType,
     pub active_video_session_id: u64,
     pub active_batch_id: Option<u64>,
     pub batch_start_time: Option<std::time::Instant>, // Anchor for shared batch transitions
-    
+
     // Metrics tracking
     metrics: Option<Arc<crate::metrics::PerformanceMetrics>>,
     video_first_frame_time: Option<std::time::Instant>, // Track when video session starts
-    
+
     // Background task handle for shader precompilation (aborted on drop)
     shader_precompile_handle: Option<tokio::task::AbortHandle>,
 }
 
 impl Renderer {
-    pub fn new<W>(name: String, ctx: Arc<WgpuContext>, window: Arc<W>, first_surface: Option<Surface<'static>>, metrics: Option<Arc<crate::metrics::PerformanceMetrics>>) -> anyhow::Result<Self> 
-    where 
-        W: HasWindowHandle + HasDisplayHandle + Sync + Send + 'static
+    pub fn new<W>(
+        name: String,
+        ctx: Arc<WgpuContext>,
+        window: Arc<W>,
+        first_surface: Option<Surface<'static>>,
+        metrics: Option<Arc<crate::metrics::PerformanceMetrics>>,
+    ) -> anyhow::Result<Self>
+    where
+        W: HasWindowHandle + HasDisplayHandle + Sync + Send + 'static,
     {
         // Reuse the first surface if provided to avoid protocol errors (multiple roles on wl_surface)
         let surface = if let Some(s) = first_surface {
@@ -523,23 +566,37 @@ impl Renderer {
         } else {
             ctx.instance.create_surface(window)?
         };
-        
+
         let caps = surface.get_capabilities(&ctx.adapter);
-        let format = caps.formats.get(0).cloned().unwrap_or(wgpu::TextureFormat::Rgba8UnormSrgb);
-        let alpha_mode = caps.alpha_modes.get(0).cloned().unwrap_or(wgpu::CompositeAlphaMode::Auto);
+        let format = caps
+            .formats
+            .first()
+            .cloned()
+            .unwrap_or(wgpu::TextureFormat::Rgba8UnormSrgb);
+        let alpha_mode = caps
+            .alpha_modes
+            .first()
+            .cloned()
+            .unwrap_or(wgpu::CompositeAlphaMode::Auto);
         // Prefer Mailbox for lower latency, fallback to Immediate, then Fifo
-        let present_mode = caps.present_modes.iter()
+        let present_mode = caps
+            .present_modes
+            .iter()
             .find(|&&m| m == wgpu::PresentMode::Mailbox)
             .copied()
             .unwrap_or_else(|| {
-                caps.present_modes.iter()
+                caps.present_modes
+                    .iter()
                     .find(|&&m| m == wgpu::PresentMode::Immediate)
                     .copied()
                     .unwrap_or(wgpu::PresentMode::Fifo)
             });
 
         if caps.formats.is_empty() {
-             info!("Surface {} created. Capabilities not yet available (transient).", name);
+            info!(
+                "Surface {} created. Capabilities not yet available (transient).",
+                name
+            );
         }
 
         let config = SurfaceConfiguration {
@@ -555,7 +612,7 @@ impl Renderer {
 
         // Clone name for background task before moving it into Self
         let name_for_bg = name.clone();
-        
+
         let mut r = Self {
             name,
             ctx: ctx.clone(),
@@ -566,7 +623,7 @@ impl Renderer {
             last_present_time: std::time::Instant::now(),
             frame_callback_pending: false,
             last_frame_request: None,
-            
+
             uniform_buffer: ctx.device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some("Transition Uniform Buffer"),
                 size: std::mem::size_of::<TransitionUniforms>() as u64,
@@ -588,7 +645,7 @@ impl Renderer {
             current_aspect: 1.0,
             prev_texture: None,
             prev_aspect: 1.0,
-            transition_progress: 1.0, 
+            transition_progress: 1.0,
             transition_start_time: None,
             transition_active: false,
             transition_just_completed: false,
@@ -621,25 +678,43 @@ impl Renderer {
             let common_transitions = vec![
                 Transition::Fade,
                 Transition::CrossZoom { strength: 0.4 },
-                Transition::Directional { direction: [0.0, 1.0] },
-                Transition::SimpleZoom { zoom_quickness: 0.5 },
-                Transition::RotateScaleFade { center: [0.5, 0.5], rotations: 1.0, scale: 0.8, back_color: [0.15, 0.15, 0.15, 1.0] },
+                Transition::Directional {
+                    direction: [0.0, 1.0],
+                },
+                Transition::SimpleZoom {
+                    zoom_quickness: 0.5,
+                },
+                Transition::RotateScaleFade {
+                    center: [0.5, 0.5],
+                    rotations: 1.0,
+                    scale: 0.8,
+                    back_color: [0.15, 0.15, 0.15, 1.0],
+                },
                 Transition::Circle,
                 Transition::LeftRight,
                 Transition::Radial { smoothness: 0.5 },
-                Transition::Bounce { shadow_colour: [0.0, 0.0, 0.0, 0.6], shadow_height: 0.075, bounces: 3.0 },
+                Transition::Bounce {
+                    shadow_colour: [0.0, 0.0, 0.0, 0.6],
+                    shadow_height: 0.075,
+                    bounces: 3.0,
+                },
                 Transition::Swirl,
             ];
-            
+
             for transition in common_transitions {
                 // Just compile the shader code - this warms the shader cache
                 // Pipeline creation happens on first use and is fast
                 let _ = crate::shaders::ShaderManager::get_builtin_shader(&transition);
             }
             let duration = start.elapsed();
-            tracing::debug!("[RENDER] {}: Background shader precompilation completed in {:.2}ms", name_for_bg, duration.as_secs_f64() * 1000.0);
-        }).abort_handle();
-        
+            tracing::debug!(
+                "[RENDER] {}: Background shader precompilation completed in {:.2}ms",
+                name_for_bg,
+                duration.as_secs_f64() * 1000.0
+            );
+        })
+        .abort_handle();
+
         r.shader_precompile_handle = Some(shader_precompile_handle);
         Ok(r)
     }
@@ -656,7 +731,10 @@ impl Renderer {
 
             // Ensure format is supported
             if !caps.formats.contains(&self.config.format) {
-                info!("Updating surface format for {} to {:?}", self.name, caps.formats[0]);
+                info!(
+                    "Updating surface format for {} to {:?}",
+                    self.name, caps.formats[0]
+                );
                 self.config.format = caps.formats[0];
             }
 
@@ -665,7 +743,7 @@ impl Renderer {
 
             info!("Configuring surface {} ({}x{})", self.name, width, height);
             self.surface.configure(&self.ctx.device, &self.config);
-            
+
             // Re-create composition texture
             // If transition is active, log that it will continue with new size
             if self.transition_active {
@@ -674,15 +752,21 @@ impl Renderer {
             }
             let texture = self.ctx.device.create_texture(&wgpu::TextureDescriptor {
                 label: Some("Composition Texture"),
-                size: wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+                size: wgpu::Extent3d {
+                    width,
+                    height,
+                    depth_or_array_layers: 1,
+                },
                 mip_level_count: 1,
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
                 format: wgpu::TextureFormat::Rgba8UnormSrgb,
-                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::RENDER_ATTACHMENT,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING
+                    | wgpu::TextureUsages::RENDER_ATTACHMENT,
                 view_formats: &[],
             });
-            self.composition_texture_view = Some(texture.create_view(&wgpu::TextureViewDescriptor::default()));
+            self.composition_texture_view =
+                Some(texture.create_view(&wgpu::TextureViewDescriptor::default()));
             self.composition_texture = Some(texture);
             // Invalidate bind groups since texture changed
             self.transition_bind_group = None;
@@ -691,7 +775,7 @@ impl Renderer {
             // Force redraw after resize
             self.needs_redraw = true;
 
-// Redundant poll removed (Audit Point 33)
+            // Redundant poll removed (Audit Point 33)
         }
         Ok(())
     }
@@ -704,55 +788,62 @@ impl Renderer {
     /// Creates it if missing or if dimensions don't match
     fn ensure_composition_texture(&mut self) -> anyhow::Result<()> {
         // Check if we need to create or recreate the composition texture
-        let needs_creation = self.composition_texture.is_none() 
-            || self.composition_texture_view.is_none();
-        
+        let needs_creation =
+            self.composition_texture.is_none() || self.composition_texture_view.is_none();
+
         // Also check if dimensions match (if texture exists but size changed, recreate it)
-        let size_mismatch = if let Some(_) = &self.composition_texture {
+        let size_mismatch = if self.composition_texture.is_some() {
             // Texture exists, check if we can determine its size
             // We can't easily check texture size, so we'll recreate if dimensions are invalid
             self.config.width == 0 || self.config.height == 0
         } else {
             false
         };
-        
+
         if needs_creation || size_mismatch {
             if self.config.width == 0 || self.config.height == 0 {
                 // Can't create texture without valid dimensions
-                return Err(anyhow::anyhow!("Cannot create composition texture: invalid dimensions ({}x{})", 
-                    self.config.width, self.config.height));
+                return Err(anyhow::anyhow!(
+                    "Cannot create composition texture: invalid dimensions ({}x{})",
+                    self.config.width,
+                    self.config.height
+                ));
             }
-            
+
             if self.transition_active {
                 warn!("[TRANSITION] {}: Composition texture missing during active transition, creating now ({}x{})", 
                     self.name, self.config.width, self.config.height);
             } else {
-                debug!("[RENDER] {}: Creating composition texture ({}x{})", 
-                    self.name, self.config.width, self.config.height);
+                debug!(
+                    "[RENDER] {}: Creating composition texture ({}x{})",
+                    self.name, self.config.width, self.config.height
+                );
             }
-            
+
             let texture = self.ctx.device.create_texture(&wgpu::TextureDescriptor {
                 label: Some("Composition Texture"),
-                size: wgpu::Extent3d { 
-                    width: self.config.width, 
-                    height: self.config.height, 
-                    depth_or_array_layers: 1 
+                size: wgpu::Extent3d {
+                    width: self.config.width,
+                    height: self.config.height,
+                    depth_or_array_layers: 1,
                 },
                 mip_level_count: 1,
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
                 format: wgpu::TextureFormat::Rgba8UnormSrgb,
-                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::RENDER_ATTACHMENT,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING
+                    | wgpu::TextureUsages::RENDER_ATTACHMENT,
                 view_formats: &[],
             });
-            self.composition_texture_view = Some(texture.create_view(&wgpu::TextureViewDescriptor::default()));
+            self.composition_texture_view =
+                Some(texture.create_view(&wgpu::TextureViewDescriptor::default()));
             self.composition_texture = Some(texture);
-            
+
             // Invalidate bind groups since texture changed
             self.transition_bind_group = None;
             self.blit_bind_group = None;
         }
-        
+
         Ok(())
     }
 
@@ -775,130 +866,172 @@ impl Renderer {
             Transition::CrossZoom { strength: 0.3 },
             Transition::Radial { smoothness: 0.5 },
             Transition::Circle,
-            Transition::Directional { direction: [1.0, 0.0] },
-            Transition::SimpleZoom { zoom_quickness: 0.5 },
-            Transition::Ripple { amplitude: 0.1, speed: 1.0 },
+            Transition::Directional {
+                direction: [1.0, 0.0],
+            },
+            Transition::SimpleZoom {
+                zoom_quickness: 0.5,
+            },
+            Transition::Ripple {
+                amplitude: 0.1,
+                speed: 1.0,
+            },
             Transition::Swirl,
-            Transition::Pixelize { squares_min: [10, 10], steps: 10 },
+            Transition::Pixelize {
+                squares_min: [10, 10],
+                steps: 10,
+            },
             Transition::Mosaic { endx: 20, endy: 20 },
         ];
-        
+
         for transition in &common_transitions {
             let _ = self.get_transition_pipeline(transition);
         }
     }
 
-    fn get_transition_pipeline(&self, transition: &Transition) -> Option<Arc<wgpu::RenderPipeline>> {
+    fn get_transition_pipeline(
+        &self,
+        transition: &Transition,
+    ) -> Option<Arc<wgpu::RenderPipeline>> {
         let name = transition.name();
-        
+
         // Check cache first (using Mutex in ctx)
         if let Some(pipe) = self.ctx.transition_pipelines.lock().get(&name) {
             return Some(pipe.clone());
         }
-        
+
         // Not in cache, compile it
-        // Note: For now we'll do synchronous compilation if missing, 
+        // Note: For now we'll do synchronous compilation if missing,
         // but it will be cached for all subsequent calls across all monitors.
-        debug!("[RENDER] {}: Compiling shared transition pipeline: {}", self.name, name);
-        
+        debug!(
+            "[RENDER] {}: Compiling shared transition pipeline: {}",
+            self.name, name
+        );
+
         // We'll move the actual compilation logic to a helper that populates the cache
         self.compile_transition_pipeline(transition)
     }
 
-    fn compile_transition_pipeline(&self, transition: &Transition) -> Option<Arc<wgpu::RenderPipeline>> {
+    fn compile_transition_pipeline(
+        &self,
+        transition: &Transition,
+    ) -> Option<Arc<wgpu::RenderPipeline>> {
         let compile_start = std::time::Instant::now();
         let name = transition.name();
-        
+
         // Get compiled WGSL shader code using ShaderManager (fragment shader only)
-        let fragment_shader_code = match crate::shaders::ShaderManager::get_builtin_shader(transition) {
-            Ok(code) => code,
-            Err(e) => {
-                error!("Failed to compile shader for {}: {}. Falling back to fade.", name, e);
-                if let Some(m) = &self.metrics {
-                    m.record_error("shader_compile");
-                }
-                // Fallback to fade
-                match crate::shaders::ShaderManager::get_builtin_shader(&Transition::Fade) {
-                    Ok(code) => code,
-                    Err(fe) => {
-                        error!("FATAL: Failed to compile fallback fade shader: {}", fe);
-                        if let Some(m) = &self.metrics {
-                            m.record_error("shader_compile_fatal");
+        let fragment_shader_code =
+            match crate::shaders::ShaderManager::get_builtin_shader(transition) {
+                Ok(code) => code,
+                Err(e) => {
+                    error!(
+                        "Failed to compile shader for {}: {}. Falling back to fade.",
+                        name, e
+                    );
+                    if let Some(m) = &self.metrics {
+                        m.record_error("shader_compile");
+                    }
+                    // Fallback to fade
+                    match crate::shaders::ShaderManager::get_builtin_shader(&Transition::Fade) {
+                        Ok(code) => code,
+                        Err(fe) => {
+                            error!("FATAL: Failed to compile fallback fade shader: {}", fe);
+                            if let Some(m) = &self.metrics {
+                                m.record_error("shader_compile_fatal");
+                            }
+                            return None;
                         }
-                        return None;
                     }
                 }
-            }
-        };
+            };
 
         // Create vertex shader module from the built-in quad.wgsl
-        let vertex_shader = self.ctx.device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("Quad Vertex Shader"),
-            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/quad.wgsl").into()),
-        });
+        let vertex_shader = self
+            .ctx
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("Quad Vertex Shader"),
+                source: wgpu::ShaderSource::Wgsl(include_str!("shaders/quad.wgsl").into()),
+            });
 
         // Create fragment shader module from the compiled GLSL transition
-        let fragment_shader = self.ctx.device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some(&format!("Transition Fragment Shader: {}", name)),
-            source: wgpu::ShaderSource::Wgsl(fragment_shader_code.into()),
-        });
+        let fragment_shader = self
+            .ctx
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some(&format!("Transition Fragment Shader: {}", name)),
+                source: wgpu::ShaderSource::Wgsl(fragment_shader_code.into()),
+            });
 
-        let pipeline_layout = self.ctx.device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some(&format!("Transition Pipeline Layout: {}", name)),
-            bind_group_layouts: &[&self.ctx.transition_bind_group_layout],
-            push_constant_ranges: &[],
-        });
+        let pipeline_layout =
+            self.ctx
+                .device
+                .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                    label: Some(&format!("Transition Pipeline Layout: {}", name)),
+                    bind_group_layouts: &[&self.ctx.transition_bind_group_layout],
+                    push_constant_ranges: &[],
+                });
 
         // Use standard format for composition (always same across all renderers)
         let composition_format = wgpu::TextureFormat::Rgba8UnormSrgb;
 
-        let pipeline = self.ctx.device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some(&format!("Transition Pipeline: {}", name)),
-            layout: Some(&pipeline_layout),
-            vertex: wgpu::VertexState {
-                module: &vertex_shader,
-                entry_point: Some("vs_main"),
-                compilation_options: Default::default(),
-                buffers: &[],
-            },
-            fragment: Some(wgpu::FragmentState {
-                module: &fragment_shader,
-                entry_point: Some("main"),  // GLSL main() compiles to "main" in WGSL
-                compilation_options: Default::default(),
-                targets: &[Some(wgpu::ColorTargetState {
-                    format: composition_format,
-                    blend: Some(wgpu::BlendState::REPLACE),
-                    write_mask: wgpu::ColorWrites::ALL,
-                })],
-            }),
-            primitive: wgpu::PrimitiveState::default(),
-            depth_stencil: None,
-            multisample: wgpu::MultisampleState::default(),
-            multiview: None,
-            cache: None,
-        });
+        let pipeline = self
+            .ctx
+            .device
+            .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some(&format!("Transition Pipeline: {}", name)),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &vertex_shader,
+                    entry_point: Some("vs_main"),
+                    compilation_options: Default::default(),
+                    buffers: &[],
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &fragment_shader,
+                    entry_point: Some("main"), // GLSL main() compiles to "main" in WGSL
+                    compilation_options: Default::default(),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: composition_format,
+                        blend: Some(wgpu::BlendState::REPLACE),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                }),
+                primitive: wgpu::PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            });
 
         let pipeline_arc = Arc::new(pipeline);
-        
+
         // Update cache
-        self.ctx.transition_pipelines.lock().insert(name, pipeline_arc.clone());
-        
+        self.ctx
+            .transition_pipelines
+            .lock()
+            .insert(name, pipeline_arc.clone());
+
         // Record shader compile CPU time
         if let Some(m) = &self.metrics {
             let compile_duration = compile_start.elapsed();
             m.record_shader_compile_cpu_time(compile_duration);
         }
-        
+
         Some(pipeline_arc)
     }
 
-    pub fn render(&mut self, context: BackendContext, frame_time: std::time::Instant) -> anyhow::Result<()> {
+    pub fn render(
+        &mut self,
+        context: BackendContext,
+        frame_time: std::time::Instant,
+    ) -> anyhow::Result<()> {
         let render_start = std::time::Instant::now();
-        
+
         // CRITICAL: Reset per-frame state at the start of each render cycle
         // This flag tracks whether a transition was rendered in THIS frame
         self.transition_rendered_this_frame = false;
-        
+
         // CRITICAL: Always render if transition is in progress, even if needs_redraw is false
         // This ensures transitions continue smoothly
         if !self.configured {
@@ -910,7 +1043,7 @@ impl Renderer {
                 return Ok(()); // Skip render until configured
             }
         }
-        
+
         // Always render if transition is active, regardless of needs_redraw
         if !self.transition_active && !self.needs_redraw {
             return Ok(()); // Skip render if no transition and no redraw needed
@@ -924,7 +1057,10 @@ impl Renderer {
         let output = match self.surface.get_current_texture() {
             Ok(t) => t,
             Err(wgpu::SurfaceError::Lost) => {
-                warn!("Surface Lost for {}. Marking not-configured to trigger re-creation.", self.name);
+                warn!(
+                    "Surface Lost for {}. Marking not-configured to trigger re-creation.",
+                    self.name
+                );
                 self.configured = false;
                 self.needs_redraw = true; // Retry ASAP
                 self.frame_callback_pending = false; // Callback won't fire for lost surface
@@ -940,19 +1076,30 @@ impl Renderer {
             Err(e) => {
                 let err_str = e.to_string();
                 if err_str.contains("timeout") {
-                    debug!("Surface acquisition timeout for {}, skipping frame.", self.name);
+                    debug!(
+                        "Surface acquisition timeout for {}, skipping frame.",
+                        self.name
+                    );
                     self.needs_redraw = true; // Try again next loop
                     return Ok(());
                 }
-                error!("Failed to get current surface texture for {}: {}", self.name, err_str);
+                error!(
+                    "Failed to get current surface texture for {}: {}",
+                    self.name, err_str
+                );
                 return Ok(());
             }
         };
-        let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
-        
-        let mut encoder = self.ctx.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("Main Render Encoder"),
-        });
+        let view = output
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+
+        let mut encoder = self
+            .ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Main Render Encoder"),
+            });
 
         // Update transition progress BEFORE checking if we should render transition
         // This ensures progress is accurate for the current frame
@@ -968,7 +1115,7 @@ impl Renderer {
                         self.name, self.transition_progress, new_progress, elapsed, self.transition_duration);
                 }
                 self.transition_progress = new_progress;
-                
+
                 // Update stats
                 if let Some(stats) = &mut self.transition_stats {
                     stats.frame_count += 1;
@@ -980,20 +1127,27 @@ impl Renderer {
                     if self.transition_active {
                         self.transition_active = false;
                         self.transition_just_completed = true;
-                        
+
                         // Log Audit Report and record metrics
                         if let Some(stats) = self.transition_stats.take() {
                             let duration = stats.start_time.elapsed();
                             let duration_secs = duration.as_secs_f64();
-                            
+
                             // Record transition duration in metrics
                             if let Some(m) = &self.metrics {
                                 m.record_transition(duration);
                             }
-                            let fps = if duration_secs > 0.001 { stats.frame_count as f64 / duration_secs } else { 0.0 };
+                            let fps = if duration_secs > 0.001 {
+                                stats.frame_count as f64 / duration_secs
+                            } else {
+                                0.0
+                            };
                             let drift = duration.as_secs_f32() - stats.target_duration;
-                            let batch_info = stats.batch_id.map(|b| format!(" (Batch: {:x})", b)).unwrap_or_default();
-                            
+                            let batch_info = stats
+                                .batch_id
+                                .map(|b| format!(" (Batch: {:x})", b))
+                                .unwrap_or_default();
+
                             info!(
                                 "[AUDIT] Transition Completed {}{}:\n  - Duration: {:.3}s (Target: {:.3}s)\n  - Frames: {} (Avg {:.1} FPS)\n  - Drift: {:.3}s",
                                 self.name, batch_info, duration.as_secs_f32(), stats.target_duration, stats.frame_count, fps, drift
@@ -1006,7 +1160,7 @@ impl Renderer {
             } else {
                 // Transition is active but start time not set yet - this is the FIRST RENDER FRAME
                 // Initialize the timer using shared batch start time if available for synchronization
-                // BUT: If the batch start time is too old (e.g. because asset loading was slow), 
+                // BUT: If the batch start time is too old (e.g. because asset loading was slow),
                 // we cap it so we don't skip the transition entirely.
                 let now = frame_time;
                 let start = match self.batch_start_time {
@@ -1015,19 +1169,20 @@ impl Renderer {
                         if age > self.transition_duration * 0.8 {
                             // Too old, start nearly from zero (0.1s in) to ensure transition is visible
                             debug!("[TRANSITION] {}: Batch start time too old ({:.3}s), capping drift to preserve transition", self.name, age);
-                            now.checked_sub(std::time::Duration::from_millis(100)).unwrap_or(now)
+                            now.checked_sub(std::time::Duration::from_millis(100))
+                                .unwrap_or(now)
                         } else {
                             batch_start
                         }
-                    },
+                    }
                     None => now,
                 };
                 self.transition_start_time = Some(start);
-                
+
                 // Calculate initial progress based on frame_time vs start
                 let elapsed = frame_time.saturating_duration_since(start).as_secs_f32();
                 self.transition_progress = (elapsed / self.transition_duration).min(1.0);
-                
+
                 // Initialize stats
                 self.transition_stats = Some(TransitionStats {
                     start_time: start,
@@ -1047,17 +1202,20 @@ impl Renderer {
         // the transition just because the texture was lazily dropped or missing.
         if self.transition_active {
             if let Err(e) = self.ensure_composition_texture() {
-                error!("[TRANSITION] {}: Failed to ensure composition texture: {}", self.name, e);
+                error!(
+                    "[TRANSITION] {}: Failed to ensure composition texture: {}",
+                    self.name, e
+                );
             }
         }
 
         // Render transition if we have all required textures and transition is active
         let should_render_transition = self.transition_active
-            && self.prev_texture.is_some() 
-            && self.current_texture.is_some() 
+            && self.prev_texture.is_some()
+            && self.current_texture.is_some()
             && self.composition_texture.is_some()
             && self.composition_texture_view.is_some();
-            
+
         // CRITICAL: Removed TRACE logs from hot path for performance
         // These were causing 5-10% CPU overhead when called every frame
 
@@ -1066,11 +1224,15 @@ impl Renderer {
             let pipeline = match self.get_transition_pipeline(&self.active_transition) {
                 Some(p) => p,
                 None => {
-                    warn!("[TRANSITION] {}: Failed to get/create transition pipeline for {}", self.name, self.active_transition.name());
+                    warn!(
+                        "[TRANSITION] {}: Failed to get/create transition pipeline for {}",
+                        self.name,
+                        self.active_transition.name()
+                    );
                     return Ok(());
                 }
             };
-            
+
             // 2. Now we can do immutable borrows
             let raw_params = self.active_transition.to_params();
             let uniforms = TransitionUniforms {
@@ -1080,7 +1242,9 @@ impl Renderer {
                 next_aspect: self.current_aspect,
                 params: bytemuck::cast(raw_params),
             };
-            self.ctx.queue.write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(&uniforms));
+            self.ctx
+                .queue
+                .write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(&uniforms));
 
             // Always update bind group to ensure it matches current texture views
             // (Optimization removed to guarantee correctness if views change)
@@ -1111,46 +1275,55 @@ impl Renderer {
                 render_pass.set_pipeline(&pipeline);
                 render_pass.set_bind_group(0, bind_group, &[]);
                 render_pass.draw(0..3, 0..1);
-                
+
                 // Mark that transition was successfully rendered this frame
                 self.transition_rendered_this_frame = true;
-                
+
                 // debug!("[TRANSITION] {}: Rendered transition frame ...", self.name);
             } else {
                 // Transition should render but bind group is missing
-                warn!("[TRANSITION] {}: Transition render FAILED - bind_group missing, transition={}", 
-                    self.name, self.active_transition.name());
+                warn!(
+                    "[TRANSITION] {}: Transition render FAILED - bind_group missing, transition={}",
+                    self.name,
+                    self.active_transition.name()
+                );
                 // Don't set transition_rendered_this_frame - transition didn't actually render
             }
-            
+
             // CLEANUP: Drop prev_texture only when transition is TRULY finished
-            if self.transition_progress >= 1.0 && self.current_texture.is_some() {
-                if self.prev_texture.is_some() {
-                    debug!("[TRANSITION] {}: Transition completed, cleaning up prev_texture", self.name);
-                    self.prev_texture = None;
-                    self.prev_texture_view = None;
-                    self.transition_bind_group = None;
-                    self.blit_bind_group = None;
-                    self.transition_start_time = None;
-                    self.transition_active = false;
-                    // Removed redundant poll (Audit Point 33)
-                }
+            if self.transition_progress >= 1.0
+                && self.current_texture.is_some()
+                && self.prev_texture.is_some()
+            {
+                debug!(
+                    "[TRANSITION] {}: Transition completed, cleaning up prev_texture",
+                    self.name
+                );
+                self.prev_texture = None;
+                self.prev_texture_view = None;
+                self.transition_bind_group = None;
+                self.blit_bind_group = None;
+                self.transition_start_time = None;
+                self.transition_active = false;
+                // Removed redundant poll (Audit Point 33)
             }
-        } 
-        
-        // Removed the "else if self.transition_active { ... }" block because we moved ensure_composition_texture 
+        }
+
+        // Removed the "else if self.transition_active { ... }" block because we moved ensure_composition_texture
         // to the top and we log missing resources above.
 
         let height = self.config.height as f32;
         if !self.transition_active {
-             let uniforms = TransitionUniforms {
-                progress: 1.0, 
+            let uniforms = TransitionUniforms {
+                progress: 1.0,
                 screen_aspect: self.config.width as f32 / height,
                 prev_aspect: 1.0,
                 next_aspect: self.current_aspect,
                 params: [[0.0; 4]; 7],
             };
-            self.ctx.queue.write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(&uniforms));
+            self.ctx
+                .queue
+                .write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(&uniforms));
         }
 
         // Logic: Show Current if ready. Else Show Prev. Else (Black).
@@ -1167,25 +1340,31 @@ impl Renderer {
             if !self.transition_active || self.prev_texture.is_none() {
                 // Transition complete or no previous texture -> show current
                 Some(BlitSource::Current)
-            } else if self.transition_active 
-                && self.prev_texture.is_some() 
+            } else if self.transition_active
+                && self.prev_texture.is_some()
                 && self.current_texture.is_some()
-                && self.composition_texture.is_some() 
-                && self.composition_texture_view.is_some() {
-                
+                && self.composition_texture.is_some()
+                && self.composition_texture_view.is_some()
+            {
                 if !self.transition_rendered_this_frame {
-                    // This can happen if setup passed but pipeline/bind_group failed, 
+                    // This can happen if setup passed but pipeline/bind_group failed,
                     // OR if this is the very first frame where we created composition but didn't render yet?
                     // Actually we ensured rendering above.
                     // If we missed rendering, showing composition (which is empty) might flash black.
                     // But usually safe to show composition as it was cleared to black.
-                    debug!("[RENDER] {}: Using composition (rendered_this_frame={})", self.name, self.transition_rendered_this_frame);
+                    debug!(
+                        "[RENDER] {}: Using composition (rendered_this_frame={})",
+                        self.name, self.transition_rendered_this_frame
+                    );
                 }
                 Some(BlitSource::Composition)
             } else if self.transition_active && self.prev_texture.is_some() {
                 // Transition active but missing required resources -> fall back to prev
-                warn!("[RENDER] {}: Transition FALLBACK to PREV - missing resources (comp_view={})", 
-                    self.name, self.composition_texture_view.is_some());
+                warn!(
+                    "[RENDER] {}: Transition FALLBACK to PREV - missing resources (comp_view={})",
+                    self.name,
+                    self.composition_texture_view.is_some()
+                );
                 Some(BlitSource::Prev)
             } else {
                 // Shouldn't happen, but fallback to current
@@ -1201,7 +1380,7 @@ impl Renderer {
             // No textures at all -> black screen
             None
         };
-        
+
         // Removed TRACE log from hot path for performance
 
         // If no blit source, we can't render anything - return early
@@ -1210,10 +1389,12 @@ impl Renderer {
             Some(s) => s,
             None => {
                 // No textures available - can't render, but keep needs_redraw for next attempt
-                debug!("[RENDER] {}: No blit source available (current={}, prev={})", 
-                    self.name, 
+                debug!(
+                    "[RENDER] {}: No blit source available (current={}, prev={})",
+                    self.name,
                     self.current_texture.is_some(),
-                    self.prev_texture.is_some());
+                    self.prev_texture.is_some()
+                );
                 return Ok(());
             }
         };
@@ -1223,10 +1404,10 @@ impl Renderer {
 
         // Always recreate bind group if source changed or doesn't exist
         // This ensures we're using the correct texture after content switches
-        let needs_recreate = self.blit_bind_group.is_none() 
-            || self.blit_source_is_composition != is_comp 
+        let needs_recreate = self.blit_bind_group.is_none()
+            || self.blit_source_is_composition != is_comp
             || self.blit_source_is_prev != is_prev;
-        
+
         if needs_recreate {
             let tex_view = match blit_source {
                 BlitSource::Current => self.current_texture_view.as_ref(),
@@ -1236,27 +1417,29 @@ impl Renderer {
             match tex_view {
                 Some(v) => {
                     // Create bind group with the texture
-                    self.blit_bind_group = Some(self.ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
-                        label: Some("Blit Bind Group"),
-                        layout: &self.ctx.blit_bind_group_layout,
-                        entries: &[
-                            wgpu::BindGroupEntry {
-                                binding: 0,
-                                resource: self.uniform_buffer.as_entire_binding(),
-                            },
-                            wgpu::BindGroupEntry {
-                                binding: 1,
-                                resource: wgpu::BindingResource::TextureView(v),
-                            },
-                            wgpu::BindGroupEntry {
-                                binding: 2,
-                                resource: wgpu::BindingResource::Sampler(&self.sampler_linear),
-                            },
-                        ],
-                    }));
+                    self.blit_bind_group = Some(self.ctx.device.create_bind_group(
+                        &wgpu::BindGroupDescriptor {
+                            label: Some("Blit Bind Group"),
+                            layout: &self.ctx.blit_bind_group_layout,
+                            entries: &[
+                                wgpu::BindGroupEntry {
+                                    binding: 0,
+                                    resource: self.uniform_buffer.as_entire_binding(),
+                                },
+                                wgpu::BindGroupEntry {
+                                    binding: 1,
+                                    resource: wgpu::BindingResource::TextureView(v),
+                                },
+                                wgpu::BindGroupEntry {
+                                    binding: 2,
+                                    resource: wgpu::BindingResource::Sampler(&self.sampler_linear),
+                                },
+                            ],
+                        },
+                    ));
                     self.blit_source_is_composition = is_comp;
                     self.blit_source_is_prev = is_prev;
-                },
+                }
                 None => {
                     // Fallback logic: if Composition fails, try Prev, then Current
                     let fallback_view = match blit_source {
@@ -1268,22 +1451,30 @@ impl Renderer {
                             })
                         }
                         BlitSource::Prev => {
-                            warn!("[RENDER] {}: Prev texture view missing, falling back to current", self.name);
+                            warn!(
+                                "[RENDER] {}: Prev texture view missing, falling back to current",
+                                self.name
+                            );
                             self.current_texture_view.as_ref()
                         }
                         BlitSource::Current => {
-                            error!("[RENDER] {}: Current texture view missing, cannot render", self.name);
+                            error!(
+                                "[RENDER] {}: Current texture view missing, cannot render",
+                                self.name
+                            );
                             None
                         }
                     };
-                    
+
                     match fallback_view {
-                            Some(v) => {
-                                // Update source to match fallback
-                                let is_comp = false;
-                                let is_prev = matches!(blit_source, BlitSource::Prev) || matches!(blit_source, BlitSource::Composition);
-                                // Recreate bind group with fallback texture
-                                self.blit_bind_group = Some(self.ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                        Some(v) => {
+                            // Update source to match fallback
+                            let is_comp = false;
+                            let is_prev = matches!(blit_source, BlitSource::Prev)
+                                || matches!(blit_source, BlitSource::Composition);
+                            // Recreate bind group with fallback texture
+                            self.blit_bind_group = Some(self.ctx.device.create_bind_group(
+                                &wgpu::BindGroupDescriptor {
                                     label: Some("Blit Bind Group (Fallback)"),
                                     layout: &self.ctx.blit_bind_group_layout,
                                     entries: &[
@@ -1297,24 +1488,27 @@ impl Renderer {
                                         },
                                         wgpu::BindGroupEntry {
                                             binding: 2,
-                                            resource: wgpu::BindingResource::Sampler(&self.sampler_linear),
+                                            resource: wgpu::BindingResource::Sampler(
+                                                &self.sampler_linear,
+                                            ),
                                         },
                                     ],
-                                }));
-                                self.blit_source_is_composition = is_comp;
-                                self.blit_source_is_prev = is_prev;
-                            }
-                            None => {
-                                error!("Texture view missing for blit source {:?} and all fallbacks failed (current={}, prev={}, composition={})", 
-                                    blit_source, 
+                                },
+                            ));
+                            self.blit_source_is_composition = is_comp;
+                            self.blit_source_is_prev = is_prev;
+                        }
+                        None => {
+                            error!("Texture view missing for blit source {:?} and all fallbacks failed (current={}, prev={}, composition={})",
+                                    blit_source,
                                     self.current_texture_view.is_some(),
                                     self.prev_texture_view.is_some(),
                                     self.composition_texture_view.is_some());
-                                return Ok(()); // Can't render anything
-                            }
+                            return Ok(()); // Can't render anything
                         }
                     }
-                };
+                }
+            };
         }
 
         // Get format-specific blit pipeline from shared context
@@ -1341,7 +1535,10 @@ impl Renderer {
                 render_pass.set_bind_group(0, bg, &[]);
                 render_pass.draw(0..3, 0..1);
             } else {
-                error!("[RENDER] {}: blit_bind_group is None, cannot render!", self.name);
+                error!(
+                    "[RENDER] {}: blit_bind_group is None, cannot render!",
+                    self.name
+                );
                 return Ok(()); // Can't render without bind group
             }
         } // render_pass dropped here
@@ -1361,51 +1558,60 @@ impl Renderer {
 
         self.ctx.queue.submit(std::iter::once(encoder.finish()));
         output.present();
-        
+
         // Note: frame_callback_pending is reset by the main loop when callback is received
         // Don't reset it here to avoid race conditions
-        
+
         if !self.transition_active {
             self.transition_start_time = None;
         }
 
         self.last_present_time = std::time::Instant::now();
-        
+
         // CRITICAL: Reset needs_redraw AFTER we've actually rendered and presented
         // This ensures we render at least once for static images
         if self.transition_active {
             // Transition in progress - MUST keep rendering until complete
             self.needs_redraw = true;
-        } else if !self.transition_active && self.valid_content_type != crate::queue::ContentType::Video {
+        } else if !self.transition_active
+            && self.valid_content_type != crate::queue::ContentType::Video
+        {
             // Transition complete and not video - can reset needs_redraw now that we've presented
             self.needs_redraw = false;
         }
         // For video, keep needs_redraw=true so we continue requesting frame callbacks
-        
+
         // Record renderer CPU time
         if let Some(m) = &self.metrics {
             let render_duration = render_start.elapsed();
             m.record_renderer_cpu_time(render_duration);
         }
-        
+
         Ok(())
     }
-    
+
     /// Request a frame callback from Wayland compositor
     /// This should be called when we need to render, and we'll wait for the callback
-    pub fn request_frame_callback(&mut self, layer_surface: &LayerSurface, qh: &QueueHandle<crate::wayland::WaylandBackend>) {
+    pub fn request_frame_callback(
+        &mut self,
+        layer_surface: &LayerSurface,
+        qh: &QueueHandle<crate::wayland::WaylandBackend>,
+    ) {
         if self.frame_callback_pending {
             // Check failsafe: if pending for > 500ms, assume lost and allow re-request
             if let Some(r) = self.last_frame_request {
-                 if r.elapsed().as_millis() > 500 {
-                      warn!("[FRAME] {}: Frame callback stuck for 500ms, re-requesting!", self.name);
-                      self.frame_callback_pending = false; // Reset to allow re-request
-                 } else {
-                      return; // Truly pending
-                 }
+                if r.elapsed().as_millis() > 500 {
+                    warn!(
+                        "[FRAME] {}: Frame callback stuck for 500ms, re-requesting!",
+                        self.name
+                    );
+                    self.frame_callback_pending = false; // Reset to allow re-request
+                } else {
+                    return; // Truly pending
+                }
             }
         }
-    
+
         let wl_surface = layer_surface.wl_surface();
         wl_surface.frame(qh, wl_surface.clone());
         self.frame_callback_pending = true;
@@ -1425,13 +1631,18 @@ impl Renderer {
         let rgba = img.to_rgba8();
         let (width, height) = rgba.dimensions();
         let data = rgba.into_raw();
-        
+
         self.upload_image_data(data, width, height)
     }
 
-    pub fn upload_image_data(&mut self, data: Vec<u8>, width: u32, height: u32) -> anyhow::Result<()> {
+    pub fn upload_image_data(
+        &mut self,
+        data: Vec<u8>,
+        width: u32,
+        height: u32,
+    ) -> anyhow::Result<()> {
         let upload_start = std::time::Instant::now();
-        
+
         // Calculate mip levels
         let mip_level_count = ((width.max(height) as f32).log2().floor() as u32) + 1;
 
@@ -1441,13 +1652,17 @@ impl Renderer {
         // Video textures can use the pool since they don't need mipmaps
         let texture = self.ctx.device.create_texture(&wgpu::TextureDescriptor {
             label: Some("Image Texture"),
-            size: wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
             mip_level_count,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::Rgba8UnormSrgb,
-            usage: wgpu::TextureUsages::TEXTURE_BINDING 
-                | wgpu::TextureUsages::COPY_DST 
+            usage: wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_DST
                 | wgpu::TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[wgpu::TextureFormat::Rgba8UnormSrgb],
         });
@@ -1466,20 +1681,29 @@ impl Renderer {
                 bytes_per_row: Some(4 * width),
                 rows_per_image: Some(height),
             },
-            wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+            wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
         );
 
         // 2. Generate Mipmaps
         if mip_level_count > 1 {
-            let mut encoder = self.ctx.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("Mipmap Generation Encoder"),
-            });
+            let mut encoder =
+                self.ctx
+                    .device
+                    .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                        label: Some("Mipmap Generation Encoder"),
+                    });
 
-            let pipeline = self.ctx.get_mipmap_pipeline(wgpu::TextureFormat::Rgba8UnormSrgb);
+            let pipeline = self
+                .ctx
+                .get_mipmap_pipeline(wgpu::TextureFormat::Rgba8UnormSrgb);
 
             for i in 1..mip_level_count {
                 let src_view = texture.create_view(&wgpu::TextureViewDescriptor {
-                    label: Some(&format!("Mip Src Level {}", i-1)),
+                    label: Some(&format!("Mip Src Level {}", i - 1)),
                     format: Some(wgpu::TextureFormat::Rgba8UnormSrgb),
                     dimension: Some(wgpu::TextureViewDimension::D2),
                     aspect: wgpu::TextureAspect::All,
@@ -1500,20 +1724,23 @@ impl Renderer {
                     array_layer_count: None,
                 });
 
-                let bind_group = self.ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
-                    label: Some(&format!("Mipmap Bind Group Level {}", i)),
-                    layout: &self.ctx.mipmap_bind_group_layout,
-                    entries: &[
-                        wgpu::BindGroupEntry {
-                            binding: 0,
-                            resource: wgpu::BindingResource::TextureView(&src_view),
-                        },
-                        wgpu::BindGroupEntry {
-                            binding: 1,
-                            resource: wgpu::BindingResource::Sampler(&self.sampler_linear),
-                        },
-                    ],
-                });
+                let bind_group = self
+                    .ctx
+                    .device
+                    .create_bind_group(&wgpu::BindGroupDescriptor {
+                        label: Some(&format!("Mipmap Bind Group Level {}", i)),
+                        layout: &self.ctx.mipmap_bind_group_layout,
+                        entries: &[
+                            wgpu::BindGroupEntry {
+                                binding: 0,
+                                resource: wgpu::BindingResource::TextureView(&src_view),
+                            },
+                            wgpu::BindGroupEntry {
+                                binding: 1,
+                                resource: wgpu::BindingResource::Sampler(&self.sampler_linear),
+                            },
+                        ],
+                    });
 
                 let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                     label: Some("Mipmap Render Pass"),
@@ -1547,7 +1774,7 @@ impl Renderer {
             base_array_layer: 0,
             array_layer_count: None,
         }));
-        
+
         self.current_texture = Some(texture);
         self.current_aspect = width as f32 / height as f32;
         self.current_texture_size = Some((width, height));
@@ -1557,39 +1784,47 @@ impl Renderer {
         self.blit_bind_group = None;
         self.blit_source_is_composition = false;
         self.blit_source_is_prev = false;
-        
+
         if self.prev_texture.is_some() {
-            self.transition_start_time = None; 
+            self.transition_start_time = None;
             self.transition_progress = 0.0;
             self.transition_active = true;
-            info!("[TRANSITION] {}: Image data uploaded - transition will start on next render frame", self.name);
+            info!(
+                "[TRANSITION] {}: Image data uploaded - transition will start on next render frame",
+                self.name
+            );
         } else {
             self.transition_active = false;
             self.transition_progress = 1.0;
             self.transition_just_completed = true; // Signal completion for instant switch
-            info!("[TRANSITION] {}: Image data uploaded (Instant) - transition signaled as complete", self.name);
+            info!(
+                "[TRANSITION] {}: Image data uploaded (Instant) - transition signaled as complete",
+                self.name
+            );
         }
-        
+
         let _duration = upload_start.elapsed();
         // Removed TRACE log - use debug! if needed for troubleshooting
-        
+
         Ok(())
     }
 
     pub fn upload_frame(&mut self, frame: &crate::video::VideoFrame) {
-        if self.valid_content_type != crate::queue::ContentType::Video || frame.session_id != self.active_video_session_id {
+        if self.valid_content_type != crate::queue::ContentType::Video
+            || frame.session_id != self.active_video_session_id
+        {
             debug!("[VIDEO] {}: Discarding stale video frame - valid_type={:?}, frame_session={}, active_session={}", 
                 self.name, self.valid_content_type, frame.session_id, self.active_video_session_id);
             return; // Discard stale video frames
         }
-        
+
         // Removed TRACE logs from hot path (called every video frame)
-        
+
         // CRITICAL: If this is the first frame after a switch (prev_texture exists but current_texture is None),
         // reset the transition start time so the transition starts fresh now that we have both textures
         // First frame after a switch is any frame that arrives when current_texture is None
         let is_first_frame_after_switch = self.current_texture.is_none();
-        
+
         // Track first frame timing for metrics (only on first frame of new video session)
         if is_first_frame_after_switch && self.video_first_frame_time.is_none() {
             self.video_first_frame_time = Some(std::time::Instant::now());
@@ -1600,7 +1835,10 @@ impl Renderer {
         let texture = if let Some(curr) = self.current_texture.take() {
             if !needs_new_texture {
                 // Size matches, reuse texture - this prevents memory leaks
-                debug!("[VIDEO] {}: Reusing existing texture {}x{}", self.name, frame.width, frame.height);
+                debug!(
+                    "[VIDEO] {}: Reusing existing texture {}x{}",
+                    self.name, frame.width, frame.height
+                );
                 curr
             } else {
                 // Size mismatch: return old texture to pool and get new one from pool
@@ -1614,7 +1852,7 @@ impl Renderer {
                     frame.width,
                     frame.height,
                     wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-                    self.metrics.as_deref()
+                    self.metrics.as_deref(),
                 )
             }
         } else {
@@ -1623,7 +1861,7 @@ impl Renderer {
                 frame.width,
                 frame.height,
                 wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-                self.metrics.as_deref()
+                self.metrics.as_deref(),
             )
         };
 
@@ -1636,95 +1874,95 @@ impl Renderer {
         let expected_stride = width * 4;
 
         // Check if source stride is 256-byte aligned (required for bytes_per_row)
-        if src_stride % 256 == 0 {
-             // Direct upload possible - map buffer in explicit scope
-             {
-                 let map = match frame.buffer.map_readable() {
-                     Ok(m) => m,
-                     Err(e) => {
-                         error!("Failed to map video buffer: {}", e);
-                         return;
-                     }
-                 };
-                 
-                 let src_data = map.as_slice();
-                 
-                 self.ctx.queue.write_texture(
+        if src_stride.is_multiple_of(256) {
+            // Direct upload possible - map buffer in explicit scope
+            {
+                let map = match frame.buffer.map_readable() {
+                    Ok(m) => m,
+                    Err(e) => {
+                        error!("Failed to map video buffer: {}", e);
+                        return;
+                    }
+                };
+
+                let src_data = map.as_slice();
+
+                self.ctx.queue.write_texture(
                     wgpu::ImageCopyTexture {
-                        texture: &texture, 
-                        mip_level: 0, 
-                        origin: wgpu::Origin3d::ZERO, 
+                        texture: &texture,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
                         aspect: wgpu::TextureAspect::All,
                     },
                     src_data,
                     wgpu::ImageDataLayout {
                         offset: 0,
-                        bytes_per_row: Some(src_stride), 
+                        bytes_per_row: Some(src_stride),
                         rows_per_image: Some(height),
                     },
                     wgpu::Extent3d {
-                        width: width,
-                        height: height,
+                        width,
+                        height,
                         depth_or_array_layers: 1,
                     },
                 );
-                 // map is dropped here, unmapping the GStreamer buffer
-             }
+                // map is dropped here, unmapping the GStreamer buffer
+            }
         } else {
             // Unaligned stride - must repack to tight packing (or aligned packing)
             // But wait, if tight packing (width*4) is ALSO not 256 aligned, we still need padding?
-             // wgpu::Queue::write_texture documentation says bytes_per_row must be multiple of 256.
-             // If width=1920, width*4=7680 (aligned).
-             // If width=1366, width*4=5464 (NOT aligned).
-             
-             // We'll repack to a 256-byte aligned stride to be safe and efficient
-             let align_mask = 255;
-             let aligned_stride = (expected_stride + align_mask) & !align_mask;
-             
-             // Map buffer and copy to temp buffer in explicit scope
-             let temp_buf = {
-                 let map = match frame.buffer.map_readable() {
-                     Ok(m) => m,
-                     Err(e) => {
-                         error!("Failed to map video buffer: {}", e);
-                         return;
-                     }
-                 };
-                 
-                 let src_data = map.as_slice();
-                 
-                 // Allocate temp buffer
-                 let mut temp_buf = Vec::with_capacity((aligned_stride * height) as usize);
-                 
-                 // Copy row by row
-                 for row in 0..height {
-                     let src_start = (row * src_stride) as usize;
-                     let src_end = src_start + expected_stride as usize; // width * 4
-                     
-                     // Append row data
-                     if src_end <= src_data.len() {
+            // wgpu::Queue::write_texture documentation says bytes_per_row must be multiple of 256.
+            // If width=1920, width*4=7680 (aligned).
+            // If width=1366, width*4=5464 (NOT aligned).
+
+            // We'll repack to a 256-byte aligned stride to be safe and efficient
+            let align_mask = 255;
+            let aligned_stride = (expected_stride + align_mask) & !align_mask;
+
+            // Map buffer and copy to temp buffer in explicit scope
+            let temp_buf = {
+                let map = match frame.buffer.map_readable() {
+                    Ok(m) => m,
+                    Err(e) => {
+                        error!("Failed to map video buffer: {}", e);
+                        return;
+                    }
+                };
+
+                let src_data = map.as_slice();
+
+                // Allocate temp buffer
+                let mut temp_buf = Vec::with_capacity((aligned_stride * height) as usize);
+
+                // Copy row by row
+                for row in 0..height {
+                    let src_start = (row * src_stride) as usize;
+                    let src_end = src_start + expected_stride as usize; // width * 4
+
+                    // Append row data
+                    if src_end <= src_data.len() {
                         temp_buf.extend_from_slice(&src_data[src_start..src_end]);
-                     } else {
-                         // Should not happen if buffer is valid
-                         break; 
-                     }
-                     
-                     // Add padding
-                     let padding = aligned_stride - expected_stride;
-                     if padding > 0 {
-                         temp_buf.extend(std::iter::repeat(0).take(padding as usize));
-                     }
-                 }
-                 
-                 // map is dropped here, unmapping the GStreamer buffer
-                 temp_buf
-             };
-             
-             self.ctx.queue.write_texture(
+                    } else {
+                        // Should not happen if buffer is valid
+                        break;
+                    }
+
+                    // Add padding
+                    let padding = aligned_stride - expected_stride;
+                    if padding > 0 {
+                        temp_buf.extend(std::iter::repeat_n(0, padding as usize));
+                    }
+                }
+
+                // map is dropped here, unmapping the GStreamer buffer
+                temp_buf
+            };
+
+            self.ctx.queue.write_texture(
                 wgpu::ImageCopyTexture {
-                    texture: &texture, 
-                    mip_level: 0, 
-                    origin: wgpu::Origin3d::ZERO, 
+                    texture: &texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
                     aspect: wgpu::TextureAspect::All,
                 },
                 &temp_buf,
@@ -1734,19 +1972,19 @@ impl Renderer {
                     rows_per_image: Some(height),
                 },
                 wgpu::Extent3d {
-                    width: width,
-                    height: height,
+                    width,
+                    height,
                     depth_or_array_layers: 1,
                 },
             );
-             // temp_buf is dropped here
+            // temp_buf is dropped here
         }
 
         // Only recreate texture view and invalidate bind groups if size changed (optimization)
         if needs_new_texture || self.current_texture_view.is_none() {
             // Explicitly drop old texture view before creating new one to free WGPU resources
             drop(self.current_texture_view.take());
-            
+
             self.current_texture_view = Some(texture.create_view(&wgpu::TextureViewDescriptor {
                 label: Some("Video Texture View"),
                 format: Some(wgpu::TextureFormat::Rgba8UnormSrgb),
@@ -1758,14 +1996,14 @@ impl Renderer {
                 array_layer_count: None,
             }));
             self.transition_bind_group = None; // Invalidate
-            self.blit_bind_group = None;      // Invalidate
+            self.blit_bind_group = None; // Invalidate
         }
-        
+
         self.current_texture = Some(texture);
         self.current_texture_size = Some((frame.width, frame.height));
         self.current_aspect = frame.width as f32 / frame.height as f32;
         self.needs_redraw = true;
-        
+
         // CRITICAL: If this is the first frame after a switch, mark transition as active
         // but DON'T set transition_start_time - let render() do that on first actual render frame
         // This ensures consistent timing behavior with image transitions
@@ -1778,7 +2016,7 @@ impl Renderer {
                     self.video_first_frame_time = None; // Reset for next video session
                 }
             }
-            
+
             if self.prev_texture.is_some() {
                 info!("[TRANSITION] {}: First video frame after switch - transition will start on first render frame", self.name);
                 self.transition_start_time = None; // Will be set on first render
@@ -1791,14 +2029,14 @@ impl Renderer {
                 self.transition_just_completed = true;
             }
         }
-        
-        debug!("[TRANSITION] {}: Video frame uploaded - current_texture={}, prev_texture={}, transition_progress={:.3}, transition_start_time={:?}", 
-            self.name, 
+
+        debug!("[TRANSITION] {}: Video frame uploaded - current_texture={}, prev_texture={}, transition_progress={:.3}, transition_start_time={:?}",
+            self.name,
             self.current_texture.is_some(),
             self.prev_texture.is_some(),
             self.transition_progress,
             self.transition_start_time.is_some());
-        
+
         // Explicitly poll device to ensure old textures are freed promptly
         // This helps prevent GPU memory accumulation during rapid video frame updates
         // Note: Using Poll (non-blocking) to avoid stalling the main loop
@@ -1810,13 +2048,13 @@ impl Renderer {
         // Always initialize transition state, even if current_texture is None
         // This ensures transitions work even when switching from empty state
         let had_current = self.current_texture.is_some();
-        
+
         if let Some(curr) = self.current_texture.take() {
             self.prev_texture_view = self.current_texture_view.take();
             self.prev_texture = Some(curr);
             self.prev_aspect = self.current_aspect;
         }
-        
+
         // Always reset transition state when switching content
         // Note: transition_start_time will be reset when new content is actually uploaded
         // transition_active will be set to true when new texture is ready (in upload_image/upload_frame)
@@ -1825,15 +2063,15 @@ impl Renderer {
         self.transition_active = false; // Will be set to true when new texture is ready
         self.transition_just_completed = false; // Reset completion flag
         self.transition_bind_group = None; // Invalidate
-        self.blit_bind_group = None;      // Invalidate
-        self.batch_start_time = None;      // Reset
+        self.blit_bind_group = None; // Invalidate
+        self.batch_start_time = None; // Reset
         self.video_first_frame_time = None; // Reset video timing for new session
         self.needs_redraw = true;
-        
+
         // OPTIMIZATION: Don't reset current_texture_size immediately.
         // We want to keep it around to see if next content (video frame) matches.
         // upload_frame will check needs_new_texture against this size.
-        
+
         debug!("[TRANSITION] {}: switch_content() - had_current={}, prev_texture={}, transition_started, current_texture cleared", 
             self.name, had_current, self.prev_texture.is_some());
     }
@@ -1841,7 +2079,10 @@ impl Renderer {
     pub fn abort_transition(&mut self) {
         if self.transition_active || self.current_texture.is_none() {
             if self.transition_active {
-                info!("[TRANSITION] {}: Aborting transition due to load failure", self.name);
+                info!(
+                    "[TRANSITION] {}: Aborting transition due to load failure",
+                    self.name
+                );
             }
             self.transition_active = false;
             self.transition_just_completed = false; // Reset flag
@@ -1852,7 +2093,7 @@ impl Renderer {
     }
 
     /// Clears the renderer to black (removes current and previous textures)
-    /// 
+    ///
     /// This explicitly drops all texture resources and forces WGPU to reclaim
     /// GPU memory immediately. Useful for cleanup and preventing memory leaks.
     #[allow(dead_code)]
@@ -1869,7 +2110,7 @@ impl Renderer {
         self.transition_active = false;
         self.transition_just_completed = false; // Reset flag
         self.transition_bind_group = None; // Invalidate
-        self.blit_bind_group = None;      // Invalidate
+        self.blit_bind_group = None; // Invalidate
         self.needs_redraw = true;
         // Reclaim memory immediately - this ensures GPU resources are freed
         // rather than waiting for WGPU's automatic cleanup
@@ -1901,12 +2142,13 @@ impl Renderer {
                 return;
             }
         };
-        
+
         // Always recreate bind group to ensure it matches current texture views
         // This prevents stale bind groups if invalidation logic elsewhere is missed
 
-        self.transition_bind_group = Some(self.ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("Transition Bind Group (Cached)"),
+        self.transition_bind_group = Some(self.ctx.device.create_bind_group(
+            &wgpu::BindGroupDescriptor {
+                label: Some("Transition Bind Group (Cached)"),
                 layout: &self.ctx.transition_bind_group_layout,
                 entries: &[
                     wgpu::BindGroupEntry {
@@ -1926,7 +2168,8 @@ impl Renderer {
                         resource: wgpu::BindingResource::Sampler(&self.sampler_linear),
                     },
                 ],
-            }));
+            },
+        ));
     }
 }
 

--- a/kaleidux-daemon/src/scripting.rs
+++ b/kaleidux-daemon/src/scripting.rs
@@ -1,8 +1,8 @@
+use kaleidux_common::{Request, Response};
 use rhai::{Engine, Scope, AST};
 use std::path::PathBuf;
-use tracing::{info, error};
 use tokio::sync::{mpsc, oneshot};
-use kaleidux_common::{Request, Response};
+use tracing::{error, info};
 
 pub struct ScriptManager {
     engine: Engine,
@@ -49,7 +49,7 @@ impl ScriptManager {
         let ast = self.engine.compile(content)?;
         self.ast = Some(ast);
         info!("Rhai script loaded from {:?}", path);
-        
+
         // Run initial setup if it exists
         if let Some(ast) = &self.ast {
             if let Err(e) = self.engine.call_fn::<()>(&mut self.scope, ast, "init", ()) {
@@ -58,13 +58,16 @@ impl ScriptManager {
                 }
             }
         }
-        
+
         Ok(())
     }
 
     pub fn tick(&mut self) {
         if let Some(ast) = &self.ast {
-            if let Err(e) = self.engine.call_fn::<()>(&mut self.scope, ast, "on_tick", ()) {
+            if let Err(e) = self
+                .engine
+                .call_fn::<()>(&mut self.scope, ast, "on_tick", ())
+            {
                 if !e.to_string().contains("not found") {
                     error!("Rhai tick error: {}", e);
                 }

--- a/kaleidux-daemon/src/video.rs
+++ b/kaleidux-daemon/src/video.rs
@@ -1,12 +1,12 @@
+use gst::prelude::*;
 use gstreamer as gst;
 use gstreamer_app as gst_app;
 use gstreamer_video as gst_video;
-use gst::prelude::*;
-use tracing::{info, debug};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread::JoinHandle;
 use tokio::sync::Semaphore;
+use tracing::{debug, info};
 
 /// Video frame containing RGBA pixel data
 /// Uses gst::Buffer to avoid copying data
@@ -36,7 +36,7 @@ impl BusWatcherPool {
             semaphore: Arc::new(Semaphore::new(max_concurrent)),
         }
     }
-    
+
     pub fn default() -> Self {
         // Default to 8 concurrent bus watchers (enough for multiple videos)
         Self::new(8)
@@ -44,9 +44,8 @@ impl BusWatcherPool {
 }
 
 // Global bus watcher pool (lazy initialized)
-static BUS_WATCHER_POOL: once_cell::sync::Lazy<Arc<BusWatcherPool>> = once_cell::sync::Lazy::new(|| {
-    Arc::new(BusWatcherPool::default())
-});
+static BUS_WATCHER_POOL: once_cell::sync::Lazy<Arc<BusWatcherPool>> =
+    once_cell::sync::Lazy::new(|| Arc::new(BusWatcherPool::default()));
 
 pub fn get_bus_watcher_pool() -> Arc<BusWatcherPool> {
     BUS_WATCHER_POOL.clone()
@@ -63,7 +62,12 @@ pub struct VideoPlayer {
 
 impl VideoPlayer {
     /// Create a new video player with a bounded channel for backpressure
-    pub fn new(uri: &str, source_id: Arc<String>, session_id: u64, frame_tx: tokio::sync::mpsc::Sender<(Arc<String>, VideoEvent)>) -> anyhow::Result<Self> {
+    pub fn new(
+        uri: &str,
+        source_id: Arc<String>,
+        session_id: u64,
+        frame_tx: tokio::sync::mpsc::Sender<(Arc<String>, VideoEvent)>,
+    ) -> anyhow::Result<Self> {
         let _video_start = std::time::Instant::now();
         let creation_start = std::time::Instant::now();
         // Use playbin - the same high-level element that gSlapper uses
@@ -84,13 +88,13 @@ impl VideoPlayer {
             };
             format!("file://{}", abs_path.display())
         };
-        
+
         info!("Setting video URI: {}", full_uri);
         pipeline.set_property("uri", &full_uri);
-        
+
         // Note: Removed buffer-size property setting - it expects gint (i32) not u64
         // and may not be necessary for preventing memory leaks
-        
+
         // Default flags (video+audio+text+softvolume) are usually fine.
         // Explicitly setting them to 3 (video+audio) requires the GstPlayFlags type.
         // pipeline.set_property("flags", 3u32);
@@ -111,8 +115,8 @@ impl VideoPlayer {
         appsink.set_sync(true); // Sync to clock
         appsink.set_drop(true); // Drop frames if late - CRITICAL for preventing buffer accumulation
         appsink.set_max_buffers(1); // Match gSlapper: 1 buffer to minimize latency and memory
-        // CRITICAL: Enable emit-signals to get callbacks, but ensure we handle them quickly
-        // The new_sample callback will be called for each frame
+                                    // CRITICAL: Enable emit-signals to get callbacks, but ensure we handle them quickly
+                                    // The new_sample callback will be called for each frame
 
         // Keep source_id for closure
         let cb_source_id = source_id.clone();
@@ -120,21 +124,21 @@ impl VideoPlayer {
         // Set up new-sample callback
         let frame_tx_clone = frame_tx.clone();
         let first_frame_logged = Arc::new(AtomicBool::new(false));
-        let creation_time_ref = creation_start.clone();
-        
+        let creation_time_ref = creation_start;
+
         appsink.set_callbacks(
             gst_app::AppSinkCallbacks::builder()
                 .new_sample(move |sink| {
                     let source_id = cb_source_id.clone();
-                    
+
                     if !first_frame_logged.load(Ordering::SeqCst) {
                         first_frame_logged.store(true, Ordering::SeqCst);
                         let duration = creation_time_ref.elapsed();
                         info!("[ASSET] {}: First video frame produced in {:.3}ms", source_id, duration.as_secs_f64() * 1000.0);
                     }
-                    
+
                     let session_id = session_id;
-                    
+
                     // CRITICAL: Pull sample and extract buffer in explicit scope
                     // This ensures sample is dropped immediately after buffer extraction
                     let (buffer, width, height, stride) = {
@@ -142,26 +146,26 @@ impl VideoPlayer {
                             Ok(s) => s,
                             Err(_) => return Err(gst::FlowError::Error),
                         };
-                        
+
                         let buffer = match sample.buffer() {
                             Some(b) => b.to_owned(),
                             None => return Err(gst::FlowError::Error),
                         };
-                        
+
                         let caps = match sample.caps() {
                             Some(c) => c,
                             None => return Err(gst::FlowError::Error),
                         };
-                        
+
                         let video_info = match gst_video::VideoInfo::from_caps(caps) {
                             Ok(vi) => vi,
                             Err(_) => return Err(gst::FlowError::Error),
                         };
 
-                        let width = video_info.width() as u32;
-                        let height = video_info.height() as u32;
+                        let width = video_info.width();
+                        let height = video_info.height();
                         let stride = video_info.stride()[0] as u32;
-                        
+
                         // sample is dropped here, releasing GStreamer sample resources
                         (buffer, width, height, stride)
                     };
@@ -200,13 +204,13 @@ impl VideoPlayer {
         // Configure appsink
         appsink.set_property("drop", true);
         appsink.set_property("max-buffers", 1u32);
-        
+
         // Set appsink as the video sink
         pipeline.set_property("video-sink", &appsink);
 
         info!("VideoPlayer created with playbin + appsink (RGBA mode)");
 
-        Ok(Self { 
+        Ok(Self {
             pipeline,
             is_running: Arc::new(AtomicBool::new(false)),
             thread_handle: None,
@@ -221,36 +225,61 @@ impl VideoPlayer {
         debug!("[VIDEO] {}: Pre-buffering video pipeline", self.source_id);
         let ret = self.pipeline.set_state(gst::State::Ready)?;
         match ret {
-            gst::StateChangeSuccess::Success => debug!("[VIDEO] {}: Pipeline state -> Ready (pre-buffered)", self.source_id),
-            gst::StateChangeSuccess::Async => debug!("[VIDEO] {}: Pipeline state -> Ready (Async, pre-buffering)", self.source_id),
+            gst::StateChangeSuccess::Success => debug!(
+                "[VIDEO] {}: Pipeline state -> Ready (pre-buffered)",
+                self.source_id
+            ),
+            gst::StateChangeSuccess::Async => debug!(
+                "[VIDEO] {}: Pipeline state -> Ready (Async, pre-buffering)",
+                self.source_id
+            ),
             _ => {}
         }
         Ok(())
     }
-    
+
     pub fn start(&mut self) -> anyhow::Result<()> {
-        info!("[VIDEO] {}: Starting playback for {}", self.source_id, self.pipeline.name());
-        
+        info!(
+            "[VIDEO] {}: Starting playback for {}",
+            self.source_id,
+            self.pipeline.name()
+        );
+
         // Start pipeline (or transition from Ready to Playing if pre-buffered)
         let ret = self.pipeline.set_state(gst::State::Playing)?;
         let duration = self.start_time.elapsed();
         match ret {
-            gst::StateChangeSuccess::Success => info!("[VIDEO] {}: Pipeline state -> Playing in {:.3}ms", self.source_id, duration.as_secs_f64() * 1000.0),
-            gst::StateChangeSuccess::Async => info!("[VIDEO] {}: Pipeline state -> Playing (Async) in {:.3}ms", self.source_id, duration.as_secs_f64() * 1000.0),
-            gst::StateChangeSuccess::NoPreroll => info!("[VIDEO] {}: Pipeline state -> Playing (Live) in {:.3}ms", self.source_id, duration.as_secs_f64() * 1000.0),
+            gst::StateChangeSuccess::Success => info!(
+                "[VIDEO] {}: Pipeline state -> Playing in {:.3}ms",
+                self.source_id,
+                duration.as_secs_f64() * 1000.0
+            ),
+            gst::StateChangeSuccess::Async => info!(
+                "[VIDEO] {}: Pipeline state -> Playing (Async) in {:.3}ms",
+                self.source_id,
+                duration.as_secs_f64() * 1000.0
+            ),
+            gst::StateChangeSuccess::NoPreroll => info!(
+                "[VIDEO] {}: Pipeline state -> Playing (Live) in {:.3}ms",
+                self.source_id,
+                duration.as_secs_f64() * 1000.0
+            ),
         }
-        
+
         // Spawn bus watcher using thread pool with semaphore to limit concurrent threads
-        let bus = self.pipeline.bus().ok_or_else(|| anyhow::anyhow!("Pipeline has no bus"))?;
+        let bus = self
+            .pipeline
+            .bus()
+            .ok_or_else(|| anyhow::anyhow!("Pipeline has no bus"))?;
         let pipeline = self.pipeline.clone();
-        
+
         self.is_running.store(true, Ordering::SeqCst);
         let is_running = self.is_running.clone();
         let frame_tx = self.frame_tx.clone();
         let source_id = self.source_id.clone();
         let pool = get_bus_watcher_pool();
         let semaphore = pool.semaphore.clone();
-        
+
         // Spawn thread but use semaphore to limit concurrent bus watchers
         // Note: We spawn a std::thread but the semaphore limits how many can run concurrently
         // The semaphore is acquired synchronously before the thread starts its loop
@@ -258,7 +287,10 @@ impl VideoPlayer {
         let rt = match tokio::runtime::Handle::try_current() {
             Ok(h) => h,
             Err(_) => {
-                tracing::error!("[VIDEO] No tokio runtime available for start() caller of {}", self.source_id);
+                tracing::error!(
+                    "[VIDEO] No tokio runtime available for start() caller of {}",
+                    self.source_id
+                );
                 return Err(anyhow::anyhow!("No tokio runtime available"));
             }
         };
@@ -276,47 +308,70 @@ impl VideoPlayer {
                     return;
                 }
             };
-            
+
             while is_running.load(Ordering::SeqCst) {
                 // Wait for up to 100ms for a message
                 match bus.timed_pop(gst::ClockTime::from_mseconds(100)) {
                     Some(msg) => {
                         use gst::MessageView;
                         match msg.view() {
-                            MessageView::StateChanged(s) if s.src().as_ref().map(|src| src.as_ptr() as usize == pipeline.as_ptr() as usize).unwrap_or(false) => {
-                                debug!("[VIDEO] {}: Pipeline state changed from {:?} to {:?}", source_id, s.old(), s.current());
+                            MessageView::StateChanged(s)
+                                if s.src()
+                                    .as_ref()
+                                    .map(|src| {
+                                        std::ptr::eq(
+                                            src.as_ptr() as *const std::ffi::c_void,
+                                            pipeline.as_ptr() as *const std::ffi::c_void,
+                                        )
+                                    })
+                                    .unwrap_or(false) =>
+                            {
+                                debug!(
+                                    "[VIDEO] {}: Pipeline state changed from {:?} to {:?}",
+                                    source_id,
+                                    s.old(),
+                                    s.current()
+                                );
                             }
                             MessageView::Eos(..) => {
                                 info!("[VIDEO] {}: End of Stream reached, looping...", source_id);
                                 // Use segment-based seeking for seamless audio (like gSlapper)
                                 // SEGMENT flag produces gapless looping, FLUSH causes audio gaps
-                                if !pipeline.seek_simple(
-                                    gst::SeekFlags::FLUSH | gst::SeekFlags::SEGMENT,
-                                    gst::ClockTime::ZERO,
-                                ).is_ok() {
+                                if pipeline
+                                    .seek_simple(
+                                        gst::SeekFlags::FLUSH | gst::SeekFlags::SEGMENT,
+                                        gst::ClockTime::ZERO,
+                                    )
+                                    .is_err()
+                                {
                                     tracing::error!("Failed to seek to start for loop");
                                 }
                             }
                             MessageView::SegmentDone(..) => {
                                 // Seamless loop restart when using segment-based seeking
-                                if !pipeline.seek_simple(
-                                    gst::SeekFlags::SEGMENT,
-                                    gst::ClockTime::ZERO,
-                                ).is_ok() {
+                                if pipeline
+                                    .seek_simple(gst::SeekFlags::SEGMENT, gst::ClockTime::ZERO)
+                                    .is_err()
+                                {
                                     tracing::error!("Failed to segment seek for loop");
                                 }
                             }
                             MessageView::Error(err) => {
-                                let error_msg = format!("Error from {:?}: {} ({:?})", 
+                                let error_msg = format!(
+                                    "Error from {:?}: {} ({:?})",
                                     err.src().map(|s| s.path_string()),
                                     err.error(),
-                                    err.debug());
-                                
+                                    err.debug()
+                                );
+
                                 tracing::error!("{}", error_msg);
-                                
+
                                 // Send error event to main thread
-                                let _ = frame_tx.blocking_send((source_id.clone(), VideoEvent::Error(error_msg)));
-                                
+                                let _ = frame_tx.blocking_send((
+                                    source_id.clone(),
+                                    VideoEvent::Error(error_msg),
+                                ));
+
                                 // Stop loop
                                 break;
                             }
@@ -330,9 +385,9 @@ impl VideoPlayer {
             }
             info!("Bus watcher thread exiting.");
         });
-        
+
         self.thread_handle = Some(handle);
-        
+
         Ok(())
     }
     pub fn stop(&mut self) -> anyhow::Result<()> {
@@ -340,21 +395,21 @@ impl VideoPlayer {
             return Ok(());
         }
         info!("Stopping video playback...");
-        
+
         // 1. Fade audio to prevent clicks/pops during transition
         self.pipeline.set_property("volume", 0.0);
-        
+
         // 2. Signal thread to stop
         self.is_running.store(false, Ordering::SeqCst);
-        
+
         // 3. Pause first (transition to Ready state first helps cleanup)
         let _ = self.pipeline.set_state(gst::State::Paused);
-        
+
         // 4. Set pipeline to Null (this stops data flow)
         //    Note: We removed the 50ms sleep as it was blocking the Wayland event loop
         //    and causing compositor disconnects when multiple transitions happen quickly
         self.pipeline.set_state(gst::State::Null)?;
-        
+
         // 5. Join thread
         // NOTE: This can block if the bus watcher thread is stuck waiting on GStreamer messages.
         // In practice, setting is_running=false and pipeline state to Null should cause the
@@ -370,7 +425,7 @@ impl VideoPlayer {
                 }
             }
         }
-        
+
         Ok(())
     }
 

--- a/kaleidux-daemon/src/x11.rs
+++ b/kaleidux-daemon/src/x11.rs
@@ -1,19 +1,17 @@
+use raw_window_handle::{
+    DisplayHandle, HandleError, HasDisplayHandle, HasWindowHandle, RawDisplayHandle,
+    RawWindowHandle, WindowHandle, XcbDisplayHandle, XcbWindowHandle,
+};
+use std::collections::HashMap;
+use std::ptr::NonNull;
+use std::sync::Arc;
+use tracing::info;
 use x11rb::connection::Connection;
 use x11rb::protocol::xproto::{
-    ConnectionExt, CreateWindowAux, Window, WindowClass, EventMask,
-    Atom, PropMode,
+    Atom, ConnectionExt, CreateWindowAux, EventMask, PropMode, Window, WindowClass,
 };
-use x11rb::xcb_ffi::XCBConnection;
 use x11rb::wrapper::ConnectionExt as _;
-use raw_window_handle::{
-    HasWindowHandle, HasDisplayHandle, WindowHandle, DisplayHandle,
-    RawWindowHandle, RawDisplayHandle,
-    XcbWindowHandle, XcbDisplayHandle, HandleError,
-};
-use std::sync::Arc;
-use std::ptr::NonNull;
-use tracing::info;
-use std::collections::HashMap;
+use x11rb::xcb_ffi::XCBConnection;
 
 /// X11 Backend handling connection and window management
 pub struct X11Backend {
@@ -22,6 +20,7 @@ pub struct X11Backend {
     pub root: Window,
     pub windows: HashMap<String, Window>,
     pub atoms: Atoms,
+    #[allow(clippy::type_complexity)]
     pub cached_monitors: parking_lot::Mutex<Option<Vec<(String, i16, i16, u16, u16)>>>,
     pub monitors_dirty: std::sync::atomic::AtomicBool,
 }
@@ -41,25 +40,43 @@ impl X11Backend {
         // Connect using XCB (requires libxcb)
         let (conn, screen_num) = XCBConnection::connect(None)?;
         let conn = Arc::new(conn);
-        
+
         let screen = &conn.setup().roots[screen_num];
         let root = screen.root;
-        
+
         // Intern atoms
-        let _net_wm_window_type = conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE")?.reply()?.atom;
-        let _net_wm_window_type_desktop = conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE_DESKTOP")?.reply()?.atom;
+        let _net_wm_window_type = conn
+            .intern_atom(false, b"_NET_WM_WINDOW_TYPE")?
+            .reply()?
+            .atom;
+        let _net_wm_window_type_desktop = conn
+            .intern_atom(false, b"_NET_WM_WINDOW_TYPE_DESKTOP")?
+            .reply()?
+            .atom;
         let _net_wm_state = conn.intern_atom(false, b"_NET_WM_STATE")?.reply()?.atom;
-        let _net_wm_state_fullscreen = conn.intern_atom(false, b"_NET_WM_STATE_FULLSCREEN")?.reply()?.atom;
-        let _net_wm_state_below = conn.intern_atom(false, b"_NET_WM_STATE_BELOW")?.reply()?.atom;
-        let _net_wm_state_sticky = conn.intern_atom(false, b"_NET_WM_STATE_STICKY")?.reply()?.atom;
-        let _net_wm_state_skip_taskbar = conn.intern_atom(false, b"_NET_WM_STATE_SKIP_TASKBAR")?.reply()?.atom;
-        
+        let _net_wm_state_fullscreen = conn
+            .intern_atom(false, b"_NET_WM_STATE_FULLSCREEN")?
+            .reply()?
+            .atom;
+        let _net_wm_state_below = conn
+            .intern_atom(false, b"_NET_WM_STATE_BELOW")?
+            .reply()?
+            .atom;
+        let _net_wm_state_sticky = conn
+            .intern_atom(false, b"_NET_WM_STATE_STICKY")?
+            .reply()?
+            .atom;
+        let _net_wm_state_skip_taskbar = conn
+            .intern_atom(false, b"_NET_WM_STATE_SKIP_TASKBAR")?
+            .reply()?
+            .atom;
+
         // Subscribe to RandR events
-        use x11rb::protocol::randr::{ConnectionExt as RandrExt};
+        use x11rb::protocol::randr::ConnectionExt as RandrExt;
         let _ = conn.randr_select_input(
             root,
             x11rb::protocol::randr::NotifyMask::OUTPUT_CHANGE
-                | x11rb::protocol::randr::NotifyMask::CRTC_CHANGE
+                | x11rb::protocol::randr::NotifyMask::CRTC_CHANGE,
         );
 
         Ok(Self {
@@ -80,83 +97,110 @@ impl X11Backend {
             monitors_dirty: std::sync::atomic::AtomicBool::new(true),
         })
     }
-    
+
+    #[allow(clippy::type_complexity)]
     pub fn get_monitors(&self) -> anyhow::Result<Vec<(String, i16, i16, u16, u16)>> {
-        use x11rb::protocol::randr::{ConnectionExt as RandrExt};
-        
+        use x11rb::protocol::randr::ConnectionExt as RandrExt;
+
         // Fast path: return cache if not dirty
-        if !self.monitors_dirty.load(std::sync::atomic::Ordering::SeqCst) {
+        if !self
+            .monitors_dirty
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
             if let Some(monitors) = self.cached_monitors.lock().as_ref() {
                 return Ok(monitors.clone());
             }
         }
 
-        let screen_res = self.conn.randr_get_screen_resources_current(self.root)?.reply()?;
+        let screen_res = self
+            .conn
+            .randr_get_screen_resources_current(self.root)?
+            .reply()?;
         let mut monitors = Vec::new();
-        
+
         for &crtc in &screen_res.crtcs {
-            let crtc_info = self.conn.randr_get_crtc_info(crtc, screen_res.config_timestamp)?.reply()?;
-            
-            if crtc_info.mode == 0 { continue; } // Inactive CRTC
-            
+            let crtc_info = self
+                .conn
+                .randr_get_crtc_info(crtc, screen_res.config_timestamp)?
+                .reply()?;
+
+            if crtc_info.mode == 0 {
+                continue;
+            } // Inactive CRTC
+
             // Find output name connected to this CRTC
             let mut name = format!("X11-{}", crtc); // Fallback
             if let Some(&output) = crtc_info.outputs.first() {
-                 let output_info = self.conn.randr_get_output_info(output, screen_res.config_timestamp)?.reply()?;
-                 name = String::from_utf8_lossy(&output_info.name).to_string();
+                let output_info = self
+                    .conn
+                    .randr_get_output_info(output, screen_res.config_timestamp)?
+                    .reply()?;
+                name = String::from_utf8_lossy(&output_info.name).to_string();
             }
-            
+
             monitors.push((
                 name,
                 crtc_info.x,
                 crtc_info.y,
                 crtc_info.width,
-                crtc_info.height
+                crtc_info.height,
             ));
         }
-        
+
         // Fallback if no RandR monitors found (rare/failsafe)
         if monitors.is_empty() {
-             let screen = &self.conn.setup().roots[self.screen_num];
-             monitors.push((
-                 "X11-0".to_string(),
-                 0, 0,
-                 screen.width_in_pixels,
-                 screen.height_in_pixels
-             ));
+            let screen = &self.conn.setup().roots[self.screen_num];
+            monitors.push((
+                "X11-0".to_string(),
+                0,
+                0,
+                screen.width_in_pixels,
+                screen.height_in_pixels,
+            ));
         }
-        
+
         // Update cache
         {
             let mut cache = self.cached_monitors.lock();
             *cache = Some(monitors.clone());
-            self.monitors_dirty.store(false, std::sync::atomic::Ordering::SeqCst);
+            self.monitors_dirty
+                .store(false, std::sync::atomic::Ordering::SeqCst);
         }
 
         Ok(monitors)
     }
 
-    pub fn create_wallpaper_window(&mut self, name: &str, x: i16, y: i16, width: u16, height: u16) -> anyhow::Result<Window> {
+    pub fn create_wallpaper_window(
+        &mut self,
+        name: &str,
+        x: i16,
+        y: i16,
+        width: u16,
+        height: u16,
+    ) -> anyhow::Result<Window> {
         let win_id = self.conn.generate_id()?;
         let screen = &self.conn.setup().roots[self.screen_num];
-        
+
         // Setup window attributes
         // REMOVED override_redirect(1) to let WM handle stacking (keeping it below apps)
         let win_aux = CreateWindowAux::new()
             .event_mask(EventMask::EXPOSURE | EventMask::STRUCTURE_NOTIFY)
             .background_pixel(screen.white_pixel);
-            
+
         self.conn.create_window(
             x11rb::COPY_DEPTH_FROM_PARENT,
             win_id,
             self.root,
-            x, y, width, height,
+            x,
+            y,
+            width,
+            height,
             0,
             WindowClass::INPUT_OUTPUT,
             0,
             &win_aux,
         )?;
-        
+
         // Set _NET_WM_WINDOW_TYPE = _NET_WM_WINDOW_TYPE_DESKTOP
         self.conn.change_property(
             PropMode::REPLACE,
@@ -167,7 +211,7 @@ impl X11Backend {
             1,
             &self.atoms._net_wm_window_type_desktop.to_ne_bytes(),
         )?;
-        
+
         // Set _NET_WM_STATE = [_NET_WM_STATE_FULLSCREEN, _NET_WM_STATE_BELOW]
         let states = [
             self.atoms._net_wm_state_fullscreen,
@@ -175,7 +219,7 @@ impl X11Backend {
             self.atoms._net_wm_state_sticky,
             self.atoms._net_wm_state_skip_taskbar,
         ];
-        
+
         let mut stated_bytes = Vec::new();
         for s in states {
             stated_bytes.extend_from_slice(&s.to_ne_bytes());
@@ -190,22 +234,28 @@ impl X11Backend {
             states.len() as u32,
             &stated_bytes,
         )?;
-        
+
         // Map window
         self.conn.map_window(win_id)?;
-        
+
         // Lower window to the bottom of the stack
         use x11rb::protocol::xproto::StackMode;
-        self.conn.configure_window(win_id, &x11rb::protocol::xproto::ConfigureWindowAux::new().stack_mode(StackMode::BELOW))?;
-        
+        self.conn.configure_window(
+            win_id,
+            &x11rb::protocol::xproto::ConfigureWindowAux::new().stack_mode(StackMode::BELOW),
+        )?;
+
         self.conn.flush()?;
         // Wait for server to process all requests (Audit Point 11)
-        let _ = self.conn.sync()?;
-        
+        self.conn.sync()?;
+
         self.windows.insert(name.to_string(), win_id);
-        
-        info!("Created X11 wallpaper window for {}: id={}, rect={}x{}@{},{}", name, win_id, width, height, x, y);
-        
+
+        info!(
+            "Created X11 wallpaper window for {}: id={}, rect={}x{}@{},{}",
+            name, win_id, width, height, x, y
+        );
+
         Ok(win_id)
     }
 }
@@ -213,7 +263,7 @@ impl X11Backend {
 /// Wrapper for RawWindowHandle for wgpu
 pub struct RawX11Surface {
     pub window_id: u32,
-    pub connection: Arc<XCBConnection>, 
+    pub connection: Arc<XCBConnection>,
     pub screen: i32,
 }
 
@@ -233,10 +283,7 @@ impl HasWindowHandle for RawX11Surface {
 impl HasDisplayHandle for RawX11Surface {
     fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
         let ptr = self.connection.get_raw_xcb_connection();
-        let handle = XcbDisplayHandle::new(
-            NonNull::new(ptr as *mut _),
-            self.screen,
-        );
+        let handle = XcbDisplayHandle::new(NonNull::new(ptr as *mut _), self.screen);
         Ok(unsafe { DisplayHandle::borrow_raw(RawDisplayHandle::Xcb(handle)) })
     }
 }


### PR DESCRIPTION
## Summary

Fixes critical memory leaks that caused memory to grow from 52MB to 6GB+ in 10 seconds. The leaks were caused by GStreamer buffers and video frames not being properly released after processing.

- [x] I did basic linting
- [  ] I'm a clown who can't code 🤡

## Changes

- Added explicit frame dropping after processing to release `gst::Buffer`
- Added explicit GStreamer sample dropping in scope to release resources immediately
- Modified frame processing to drain all frames each loop (keeping latest per source)
- Added renderer existence checks to prevent race conditions
- Removed hard caps on channels (restored to reasonable defaults: 30 frames, unbounded images)
- Fixed buffer-size property type error that was causing video player panics

## Testing

1. Built with `cargo build --release`
2. Ran `kaleidux-daemon --log 4` and monitored memory usage
3. Memory is now stable at ~350MB instead of growing to 6GB+ in 10 seconds
4. Tested with 3 monitors simultaneously loading images and videos
5. Verified videos play correctly without panics

## Breaking Changes

None

## Related Issues

Fixes memory leak issue reported in logs showing 52MB → 6GB growth in 10 seconds which then goes to 20gb to 64gb when left alone.