### PR TITLE
fix frame callback on niri

### DIFF
--- a/kaleidux-daemon/src/renderer.rs
+++ b/kaleidux-daemon/src/renderer.rs
@@ -1617,6 +1617,7 @@ impl Renderer {
 
         let wl_surface = layer_surface.wl_surface();
         wl_surface.frame(qh, wl_surface.clone());
+        wl_surface.commit(); // Commit to prompt compositor to send frame callback
         self.frame_callback_pending = true;
         self.last_frame_request = Some(std::time::Instant::now());
         tracing::debug!("[FRAME] {}: Requested frame callback (configured={}, needs_redraw={}, transition_progress={:.3})", 


### PR DESCRIPTION
closes #7 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure frame callbacks fire on niri by committing the surface right after requesting a frame. This prevents render stalls where callbacks never arrive (closes #7).

- **Bug Fixes**
  - Add `wl_surface.commit()` immediately after `wl_surface.frame(...)` so the compositor schedules the callback.

<sup>Written for commit 7a0149a7190d3b445b6d218975ed0a12985131c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

